### PR TITLE
UHF-5459 Radioactivity most read news

### DIFF
--- a/.env
+++ b/.env
@@ -23,3 +23,5 @@ DRUPAL_SYNC_SOURCE=main
 
 # Public webroot
 DRUPAL_WEBROOT=public
+
+DRUPAL_SYNC_FILES=no

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/jsonapi_extras": "^3.20",
         "drupal/openapi_jsonapi": "^3.0",
         "drupal/openapi_ui_redoc": "^1.0@RC",
+        "drupal/radioactivity": "^4.0",
         "drupal/redis": "^1.5",
         "drush/drush": "^10.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb7f731fbf4a39c6dc3c7cad2b3e1d8b",
+    "content-hash": "43d3e447958a9790336ef81293c01d40",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5752,6 +5752,68 @@
             "homepage": "https://www.drupal.org/project/purge",
             "support": {
                 "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/radioactivity",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/radioactivity.git",
+                "reference": "4.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/radioactivity-4.0.2.zip",
+                "reference": "4.0.2",
+                "shasum": "5c865894800def89cd2eab338f5816a39cb451fe"
+            },
+            "require": {
+                "drupal/core": "^9",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "drupal/rules": "^3.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.2",
+                    "datestamp": "1650436293",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Sutharsan",
+                    "homepage": "https://www.drupal.org/user/73854"
+                },
+                {
+                    "name": "matthewmessmer",
+                    "homepage": "https://www.drupal.org/user/2496364"
+                },
+                {
+                    "name": "skiminki",
+                    "homepage": "https://www.drupal.org/user/265179"
+                }
+            ],
+            "description": "Provides a field which can be used to track popularity, views, etc.",
+            "homepage": "https://www.drupal.org/project/radioactivity",
+            "support": {
+                "source": "https://git.drupalcode.org/project/radioactivity",
+                "issues": "https://www.drupal.org/project/issues/radioactivity"
             }
         },
         {

--- a/conf/cmi/core.entity_form_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_form_display.node.news_item.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.news_item.field_news_item_links_title
     - field.field.node.news_item.field_news_item_tags
     - field.field.node.news_item.field_news_neighbourhoods
+    - field.field.node.news_item.field_radioactivity
     - field.field.node.news_item.field_short_title
     - node.type.news_item
   module:
@@ -22,6 +23,7 @@ dependencies:
     - paragraphs
     - path
     - publication_date
+    - radioactivity
     - scheduler
     - select2
 third_party_settings:
@@ -181,6 +183,12 @@ content:
       autocomplete: false
       match_operator: CONTAINS
       match_limit: 10
+    third_party_settings: {  }
+  field_radioactivity:
+    type: radioactivity_reference
+    weight: 28
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_short_title:
     type: string_textfield

--- a/conf/cmi/core.entity_view_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.default.yml
@@ -12,12 +12,14 @@ dependencies:
     - field.field.node.news_item.field_news_item_links_title
     - field.field.node.news_item.field_news_item_tags
     - field.field.node.news_item.field_news_neighbourhoods
+    - field.field.node.news_item.field_radioactivity
     - field.field.node.news_item.field_short_title
     - node.type.news_item
   module:
     - entity_reference_revisions
     - helfi_content
     - link
+    - radioactivity
     - user
 _core:
   default_config_hash: tqlFC6ku-KOPGVDzzfRA0SSzFD_5iAMqKfpTMcUyqBg
@@ -77,6 +79,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_radioactivity:
+    type: radioactivity_reference_emitter
+    label: above
+    settings:
+      energy: !!float 10
+      display: false
+      decimals: !!float 0
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_short_title:
     type: string

--- a/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.news_item.field_news_item_links_title
     - field.field.node.news_item.field_news_item_tags
     - field.field.node.news_item.field_news_neighbourhoods
+    - field.field.node.news_item.field_radioactivity
     - field.field.node.news_item.field_short_title
     - node.type.news_item
   module:
@@ -72,5 +73,6 @@ hidden:
   field_news_item_links_link: true
   field_news_item_tags: true
   field_news_neighbourhoods: true
+  field_radioactivity: true
   langcode: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.node.news_item.tiny_teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.tiny_teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.news_item.field_news_item_links_title
     - field.field.node.news_item.field_news_item_tags
     - field.field.node.news_item.field_news_neighbourhoods
+    - field.field.node.news_item.field_radioactivity
     - field.field.node.news_item.field_short_title
     - image.style.tiny_square_image
     - node.type.news_item
@@ -67,5 +68,6 @@ hidden:
   field_news_item_links_title: true
   field_news_item_tags: true
   field_news_neighbourhoods: true
+  field_radioactivity: true
   langcode: true
   toc_enabled: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -97,6 +97,7 @@ module:
   purge_processor_cron: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
+  radioactivity: 0
   redirect: 0
   redis: 0
   responsive_image: 0

--- a/conf/cmi/field.field.node.news_item.field_radioactivity.yml
+++ b/conf/cmi/field.field.node.news_item.field_radioactivity.yml
@@ -1,0 +1,29 @@
+uuid: abbf936a-e850-42da-8834-d15bd0f16956
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_radioactivity
+    - node.type.news_item
+  module:
+    - radioactivity
+id: node.news_item.field_radioactivity
+field_name: field_radioactivity
+entity_type: node
+bundle: news_item
+label: Radioactivity
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:radioactivity'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+  default_energy: !!float 0
+field_type: radioactivity_reference

--- a/conf/cmi/field.storage.node.field_radioactivity.yml
+++ b/conf/cmi/field.storage.node.field_radioactivity.yml
@@ -1,0 +1,24 @@
+uuid: e5990386-c243-4d98-9a3d-4dcd5627f4ab
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - radioactivity
+id: node.field_radioactivity
+field_name: field_radioactivity
+entity_type: node
+type: radioactivity_reference
+settings:
+  target_type: radioactivity
+  profile: decay
+  granularity: 86400
+  halflife: 604800
+  cutoff: !!float 1
+module: radioactivity
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.news_item.field_radioactivity.yml
+++ b/conf/cmi/language/fi/field.field.node.news_item.field_radioactivity.yml
@@ -1,0 +1,1 @@
+label: Radioaktiivisuus

--- a/conf/cmi/language/fi/views.view.radioactivity.yml
+++ b/conf/cmi/language/fi/views.view.radioactivity.yml
@@ -1,0 +1,7 @@
+display:
+  default:
+    display_options:
+      title: 'Luetuimmat uutiset'
+  block_1:
+    display_options:
+      block_description: 'Luetuimmat uutiset'

--- a/conf/cmi/views.view.radioactivity.yml
+++ b/conf/cmi/views.view.radioactivity.yml
@@ -1,0 +1,391 @@
+uuid: a111a6e7-b678-4fda-81d3-40704c18cdae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_radioactivity
+    - node.type.news_item
+  module:
+    - node
+    - radioactivity
+id: radioactivity
+label: Radioactivity
+module: views
+description: 'Most viewed news items sorted by radioactivity'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Most read news'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_radioactivity:
+          id: field_radioactivity
+          table: node__field_radioactivity
+          field: field_radioactivity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: radioactivity_reference_value
+          settings:
+            decimals: !!float 0
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        energy:
+          id: energy
+          table: radioactivity
+          field: energy
+          relationship: field_radioactivity
+          group_type: group
+          admin_label: ''
+          entity_type: radioactivity
+          entity_field: energy
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            news_item: news_item
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        field_radioactivity:
+          id: field_radioactivity
+          table: node__field_radioactivity
+          field: field_radioactivity
+          relationship: none
+          group_type: group
+          admin_label: 'field_radioactivity: Radioactivity'
+          plugin_id: standard
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_radioactivity'
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Most read news'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_radioactivity'


### PR DESCRIPTION
# Radioactivity most read news [UHF-5459](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5459)
Radioactivity module allows sorting content by the popularity of the content. Popularity will diminish over time allowing new content to show up as popular content.

## What was done
* Added radioactivity field rendering to hdbt theme's news item's template
* Added radioactivity field to news item content type
* Created 'Most read news' -block which sorts content by radioactivity.

## How to install
* Checkout this branch
* Update the hdbt theme
   * `composer require drupal/hdbt:dev-UHF-5459_most_read_articles`
* Make fresh
* If you have no default content you can create some by running: 
   * `drush pmu helfi_etusivu`
   * `drush en helfi_etusivu`
   * `drush radioactivity:fix-references`

## How to test
* You must have news items created
* Open the radioactivity view: /admin/structure/views/view/radioactivity, keep it open to make this easier.
* Open some of the news item content pages (found from the view's preview for example), 
* Try refreshing one of the news pages multiple times
* Run `drush cron`
    * You should see message: Processed n radioactivity incident
* Refresh the radioactivity view, check the preview
    * The view's preview should show the news items ordered by radioactivity. (radioactivity number is under the title)
* (Optional) wait for a day or two, run drush cron and you should see message: Processed n radioactivity decays.

## Other PRs
* [Added radioactivity field rendering to news item template](https://github.com/City-of-Helsinki/drupal-hdbt/pull/301)
