### PR TITLE
UHF-5662: Added new design for hero

### DIFF
--- a/conf/cmi/field.field.paragraph.hero.field_hero_design.yml
+++ b/conf/cmi/field.field.paragraph.hero.field_hero_design.yml
@@ -14,7 +14,7 @@ field_name: field_hero_design
 entity_type: paragraph
 bundle: hero
 label: Layout
-description: 'Set the hero layout from the menu. The layout affects what information is required below.'
+description: 'Set the hero layout from the menu. The layout affects what information is required below. Use with search layout only on the frontpage of this instance.'
 required: true
 translatable: false
 default_value:

--- a/conf/cmi/field.storage.paragraph.field_hero_design.yml
+++ b/conf/cmi/field.storage.paragraph.field_hero_design.yml
@@ -34,6 +34,9 @@ settings:
     -
       value: diagonal
       label: Diagonal
+    -
+      value: with-search
+      label: 'With search'
   allowed_values_function: ''
 module: options
 locked: false

--- a/conf/cmi/language/fi/field.field.paragraph.hero.field_hero_design.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.hero.field_hero_design.yml
@@ -1,2 +1,2 @@
 label: Asettelu
-description: 'Valitse heron asettelu valikosta. Valittu asettelu vaikuttaa siihen, mitä lisätietoja sinun pitää täyttää.'
+description: 'Valitse heron asettelu valikosta. Valittu asettelu vaikuttaa siihen, mitä lisätietoja sinun pitää täyttää. Käytä hakua ainoastaan instanssin etusivulla.'

--- a/conf/cmi/language/fi/field.storage.paragraph.field_hero_design.yml
+++ b/conf/cmi/language/fi/field.storage.paragraph.field_hero_design.yml
@@ -14,3 +14,5 @@ settings:
       label: Taustakuva
     -
       label: Diagonaalinen
+    -
+      label: Haulla


### PR DESCRIPTION
# Hero with search [UHF-5662](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5662)

## What was done
* Added new design for hero paragraph and a placeholder for the upcoming search

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT theme
    * `composer require drupal/hdbt:dev-UHF-5662-hero-with-search`
* Update the HDBT Admin theme
    * `composer require drupal/hdbt_admin:dev-UHF-5662-hero-with-search`
* Checkout this branch `UHF-5662-hero-with-search`
* Run `make drush-cim`
* Run `make drush-cr`

## How to test
* Create a new landing page
* Add the hero block and select "With search" as the layout design
* The description field should be hidden when with search is selected
* Save the page and go check that the placeholder input field is now visible in the hero
* The design should otherwise be the same as when diagonal is selected

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/146
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/331
