### PR TITLE
UHF-5912 elasticsearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-recommended": "^9.3",
         "drupal/draggableviews": "^2.0",
+        "drupal/elasticsearch_connector": "^7.0@alpha",
         "drupal/external_entities": "^2.0@alpha",
         "drupal/hdbt": "^3.0",
         "drupal/hdbt_admin": "^1.0",
@@ -27,6 +28,7 @@
         "drupal/openapi_ui_redoc": "^1.0@RC",
         "drupal/radioactivity": "^4.0",
         "drupal/redis": "^1.5",
+        "drupal/search_api": "^1.23",
         "drush/drush": "^10.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7568ed073b6bb842e18e4fcc83cd180",
+    "content-hash": "064ada5ae889c1aef0efa1030084cf94",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -17637,6 +17637,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/elasticsearch_connector": 15,
         "drupal/external_entities": 15,
         "drupal/helfi_drupal_tools": 20,
         "drupal/openapi_ui_redoc": 5
@@ -17647,5 +17648,5 @@
         "ext-libxml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -27,6 +27,7 @@ module:
   easy_breadcrumb: 0
   editor: 0
   editoria11y: 0
+  elasticsearch_connector: 0
   entity: 0
   entity_reference_revisions: 0
   entity_usage: 0
@@ -111,6 +112,7 @@ module:
   scheduler: 0
   schemata: 0
   schemata_json_schema: 0
+  search_api: 0
   select2: 0
   select2_icon: 0
   serialization: 0

--- a/conf/cmi/elasticsearch_connector.cluster.news.yml
+++ b/conf/cmi/elasticsearch_connector.cluster.news.yml
@@ -1,0 +1,19 @@
+uuid: d3bd7e12-ae1b-415e-9d88-ca161c6a578a
+langcode: en
+status: '1'
+dependencies: {  }
+cluster_id: news
+name: Uutiset
+url: 'http://elastic:9200'
+options:
+  multiple_nodes_connection: false
+  use_authentication: 0
+  authentication_type: Basic
+  username: ''
+  password: ''
+  timeout: '3'
+  rewrite:
+    rewrite_index: 1
+    index:
+      prefix: ''
+      suffix: ''

--- a/conf/cmi/search_api.index.news.yml
+++ b/conf/cmi/search_api.index.news.yml
@@ -1,0 +1,132 @@
+uuid: e0d1f3e4-dd1b-4f4d-84c5-09260d669dbd
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_file
+    - field.storage.node.field_main_image
+    - field.storage.node.field_news_groups
+    - field.storage.node.field_news_neighbourhoods
+    - field.storage.node.field_news_item_tags
+    - field.storage.node.field_short_title
+    - search_api.server.news
+  module:
+    - node
+    - publication_date
+    - file
+    - media
+    - taxonomy
+    - search_api
+id: news
+name: news
+description: ''
+read_only: false
+field_settings:
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
+  field_main_image:
+    label: 'Main image » Media » File » Tiedosto » URI'
+    datasource_id: 'entity:node'
+    property_path: 'field_main_image:entity'
+    type: etusivu_image
+    dependencies:
+      config:
+        - field.storage.node.field_main_image
+  field_news_groups:
+    label: 'News groups '
+    datasource_id: 'entity:node'
+    property_path: 'field_news_groups:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_news_groups
+      module:
+        - taxonomy
+  field_news_item_tags:
+    label: 'News tags'
+    datasource_id: 'entity:node'
+    property_path: 'field_news_item_tags:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_news_item_tags
+      module:
+        - taxonomy
+  field_news_neighbourhoods:
+    label: 'News neighbourhoods'
+    datasource_id: 'entity:node'
+    property_path: 'field_news_neighbourhoods:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_news_neighbourhoods
+      module:
+        - taxonomy
+  field_short_title:
+    label: 'Short title'
+    datasource_id: 'entity:node'
+    property_path: field_short_title
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_short_title
+  published_at:
+    label: Julkaisuaika
+    datasource_id: 'entity:node'
+    property_path: published_at
+    type: date
+    dependencies:
+      module:
+        - publication_date
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: string
+    dependencies:
+      module:
+        - node
+  url:
+    label: URI
+    property_path: search_api_url
+    type: string
+    configuration:
+      absolute: true
+  uuid:
+    label: UUID
+    datasource_id: 'entity:node'
+    property_path: uuid
+    type: string
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: false
+      selected:
+        - news_item
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  entity_status: {  }
+  entity_type: {  }
+  language_with_fallback: {  }
+  rendered_item: {  }
+tracker_settings:
+  default:
+    indexing_order: lifo
+options:
+  cron_limit: 50
+  index_directly: true
+  track_changes_in_references: true
+server: news

--- a/conf/cmi/search_api.server.news.yml
+++ b/conf/cmi/search_api.server.news.yml
@@ -1,0 +1,15 @@
+uuid: c7760bbd-13db-44f6-822e-e450a80d088c
+langcode: en
+status: true
+dependencies:
+  module:
+    - elasticsearch_connector
+id: news
+name: news
+description: ''
+backend: elasticsearch
+backend_config:
+  server_description: ''
+  cluster_settings:
+    cluster: news
+  fuzziness: auto

--- a/conf/cmi/search_api.settings.yml
+++ b/conf/cmi/search_api.settings.yml
@@ -1,0 +1,28 @@
+_core:
+  default_config_hash: b2zIRm9Jv3SB60NYdZkZHxH8-KdEa-Xa48-4NsIi4lg
+default_cron_limit: 50
+cron_worker_runtime: 15
+default_tracker: default
+tracking_page_size: 100
+boost_factors:
+  - !!float 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - !!float 1
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - !!float 2
+  - !!float 3
+  - !!float 5
+  - !!float 8
+  - !!float 13
+  - !!float 21

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}-varnish.loadbalancer.server.port=6081"
       - "traefik.docker.network=stonehenge-network"
   robo:
-    image: ghcr.io/city-of-helsinki/drupal-robo:latest
+    image: ghcr.io/city-of-helsinki/drupal-robo:alpine
     shm_size: '2gb'
     tty: true
     volumes:
@@ -89,6 +89,37 @@ services:
     extra_hosts:
       - "${DRUPAL_HOSTNAME}:host-gateway"
       - "varnish-${DRUPAL_HOSTNAME}:host-gateway"
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    container_name: "${COMPOSE_PROJECT_NAME}-elastic"
+    environment:
+      - node.name="${COMPOSE_PROJECT_NAME}-elastic"
+      - discovery.seed_hosts=elastic
+      - cluster.name=es-docker-cluster
+      - cluster.initial_master_nodes="${COMPOSE_PROJECT_NAME}-elastic"
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "http.cors.allow-origin=*"
+      - "http.cors.enabled=true"
+      - "http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+      - "http.cors.allow-credentials=true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200:9200
+    networks:
+      - internal
+      - stonehenge-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.entrypoints=https"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.rule=Host(`elastic-${DRUPAL_HOSTNAME}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-elastic.tls=true"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-elastic.loadbalancer.server.port=9200"
+      - "traefik.docker.network=stonehenge-network"
+      - "traefik.port=9200"
 networks:
   internal:
     external: false

--- a/public/modules/custom/helfi_etusivu/src/Plugin/search_api/data_type/Image.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/search_api/data_type/Image.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\helfi_etusivu\Plugin\search_api\data_type;
+
+use Drupal\image\Entity\ImageStyle;
+use Drupal\search_api\Plugin\search_api\data_type\StringDataType;
+
+/**
+ * Get file url from media entity.
+ *
+ * @SearchApiDataType(
+ *   id = "etusivu_image",
+ *   label = @Translation("Image"),
+ *   description = @Translation("Image"),
+ *   default = "true"
+ * )
+ */
+class Image extends StringDataType {
+  public function getValue($value) {
+    if (!$value->hasField('field_media_image')) {
+      return '';
+    }
+
+    if ($file = $value->get('field_media_image')->entity) {
+      try {
+        $imageStyle = ImageStyle::load('3_2_l');
+        return $imageStyle->buildUrl($file->getFileUri());
+      }
+      catch (\Exception) {
+      }
+    }
+  }
+}

--- a/public/modules/custom/helfi_etusivu/src/Plugin/search_api/data_type/Image.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/search_api/data_type/Image.php
@@ -16,18 +16,19 @@ use Drupal\search_api\Plugin\search_api\data_type\StringDataType;
  * )
  */
 class Image extends StringDataType {
+
+  /**
+   * {@inheritDoc}
+   */
   public function getValue($value) {
     if (!$value->hasField('field_media_image')) {
       return '';
     }
 
     if ($file = $value->get('field_media_image')->entity) {
-      try {
-        $imageStyle = ImageStyle::load('3_2_l');
-        return $imageStyle->buildUrl($file->getFileUri());
-      }
-      catch (\Exception) {
-      }
+      $imageStyle = ImageStyle::load('3_2_l');
+      return $imageStyle->buildUrl($file->getFileUri());
     }
   }
+
 }

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -52,13 +52,13 @@ $settings['siteimprove_id'] = getenv('SITEIMPROVE_ID');
 
 // Elasticsearch settings.
 if(getenv('ELASTIC_CONNECTOR_URL')) {
-  $config['elasticsearch_connector.cluster.news']['url'] = getenv('ELASTIC_CONNECTOR_URL');
+  $config['elasticsearch_connector.cluster.news']['url'] = getenv('ELASTICSEARCH_URL');
 
-  if(getenv('ELASTIC_INTERNAL_USER') && getenv('ELASTIC_INTERNAL_PWD')) {
+  if(getenv('ELASTIC_USER') && getenv('PASSWORD')) {
     $config['elasticsearch_connector.cluster.news']['options']['use_authentication'] = '1';
     $config['elasticsearch_connector.cluster.news']['options']['authentication_type'] = 'Basic';
-    $config['elasticsearch_connector.cluster.news']['options']['username'] = getenv('ELASTIC_INTERNAL_USER');
-    $config['elasticsearch_connector.cluster.news']['options']['password'] = getenv('ELASTIC_INTERNAL_PWD');
+    $config['elasticsearch_connector.cluster.news']['options']['username'] = getenv('ELASTIC_USER');
+    $config['elasticsearch_connector.cluster.news']['options']['password'] = getenv('ELASTIC-PASSWORD');
   }
 }
 

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -50,6 +50,18 @@ $config['siteimprove.settings']['api_key'] = getenv('SITEIMPROVE_API_KEY');
 $settings['matomo_site_id'] = getenv('MATOMO_SITE_ID');
 $settings['siteimprove_id'] = getenv('SITEIMPROVE_ID');
 
+// Elasticsearch settings.
+if(getenv('ELASTIC_CONNECTOR_URL')) {
+  $config['elasticsearch_connector.cluster.news']['url'] = getenv('ELASTIC_CONNECTOR_URL');
+
+  if(getenv('ELASTIC_INTERNAL_USER') && getenv('ELASTIC_INTERNAL_PWD')) {
+    $config['elasticsearch_connector.cluster.news']['options']['use_authentication'] = '1';
+    $config['elasticsearch_connector.cluster.news']['options']['authentication_type'] = 'Basic';
+    $config['elasticsearch_connector.cluster.news']['options']['username'] = getenv('ELASTIC_INTERNAL_USER');
+    $config['elasticsearch_connector.cluster.news']['options']['password'] = getenv('ELASTIC_INTERNAL_PWD');
+  }
+}
+
 // Drupal route(s).
 $routes = (getenv('DRUPAL_ROUTES')) ? explode(',', getenv('DRUPAL_ROUTES')) : [];
 $routes[] = 'http://127.0.0.1';


### PR DESCRIPTION
# [UHF-5912](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5912)
Elasticsearch setup + news index.

## What was done
* Set up local elasticsearch
* Configured Searchapi & elasticsearch_connector
* Created index for news
* Updated settings.php  
* Added custom datatype in order to get image style url indexed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-5912_elasticsearch`
  * `make up` - to get the ES container up and running
  * `make fresh`
* Run `make drush-cr`

## How to test
* Make sure you have created one or more news
* Run elasticsearch indexing by pressing "index now" in `/admin/config/search/search-api/index/news`
* Go to `localhost:9200/_search?pretty=true`
* You should see the data entered to the news items
* The data found from elasticsearch should match the layout (Filters & data found under All news) https://app.abstract.com/share/8be8c801-48b8-40b5-866e-ec197360fccf?collectionLayerId=d66cb334-acef-41a8-a6c2-86432f251928&mode=design&sha=a416520a939a3528aa9a1550f10c3da3a3d38dbe  

* [X] Check that this feature works
* [x] Check that code follows our standards
