### PR TITLE
UHF-5843: Global navigation POC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,15 @@
         "drupal/helfi_platform_config": "^2.0",
         "drupal/helfi_proxy": "^2.0",
         "drupal/helfi_tunnistamo": "^2.0",
+        "drupal/json_field": "^1.0@RC",
         "drupal/jsonapi_extras": "^3.20",
         "drupal/openapi_jsonapi": "^3.0",
         "drupal/openapi_ui_redoc": "^1.0@RC",
         "drupal/radioactivity": "^4.0",
         "drupal/redis": "^1.5",
         "drupal/search_api": "^1.23",
-        "drush/drush": "^10.4"
+        "drush/drush": "^10.4",
+        "josdejong/jsoneditor": "^5.29"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -112,6 +114,23 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "josdejong/jsoneditor",
+                "version": "v5.29.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip",
+                    "type": "zip"
+                },
+                "source": {
+                    "url": "https://github.com/josdejong/jsoneditor",
+                    "type": "git",
+                    "reference": "v5.29.1"
+                }
+            }
         }
     ],
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "064ada5ae889c1aef0efa1030084cf94",
+    "content-hash": "15469aef90354539fd59de9013ca6da4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4712,6 +4712,64 @@
             }
         },
         {
+            "name": "drupal/json_field",
+            "version": "1.0.0-rc4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/json_field.git",
+                "reference": "8.x-1.0-rc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/json_field-8.x-1.0-rc4.zip",
+                "reference": "8.x-1.0-rc4",
+                "shasum": "e03602d3bbcd249ae589f87e10e2b904088777c6"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "swaggest/json-schema": "^0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-rc4",
+                    "datestamp": "1620937410",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://www.drupal.org/node/2653746/committers",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Jaesin",
+                    "homepage": "https://www.drupal.org/user/841054"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                }
+            ],
+            "description": "Provides a JSON field, formatter and views integration",
+            "homepage": "https://www.drupal.org/project/json_field",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/json_field",
+                "issues": "https://www.drupal.org/project/issues/json_field"
+            }
+        },
+        {
             "name": "drupal/jsonapi_extras",
             "version": "3.20.0",
             "source": {
@@ -8332,6 +8390,20 @@
             "time": "2022-03-20T21:51:18+00:00"
         },
         {
+            "name": "josdejong/jsoneditor",
+            "version": "v5.29.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/josdejong/jsoneditor",
+                "reference": "v5.29.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip"
+            },
+            "type": "drupal-library"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.12",
             "source": {
@@ -9859,6 +9931,54 @@
             "time": "2021-03-21T15:43:46+00:00"
         },
         {
+            "name": "phplang/scope-exit",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phplang/scope-exit.git",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phplang/scope-exit/zipball/239b73abe89f9414aa85a7ca075ec9445629192b",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpLang\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Sara Golemon",
+                    "email": "pollita@php.net",
+                    "homepage": "https://twitter.com/SaraMG",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Emulation of SCOPE_EXIT construct from C++",
+            "homepage": "https://github.com/phplang/scope-exit",
+            "keywords": [
+                "cleanup",
+                "exit",
+                "scope"
+            ],
+            "support": {
+                "issues": "https://github.com/phplang/scope-exit/issues",
+                "source": "https://github.com/phplang/scope-exit/tree/master"
+            },
+            "time": "2016-09-17T00:15:18+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -10431,6 +10551,100 @@
                 "source": "https://github.com/stackphp/builder/tree/v1.0.6"
             },
             "time": "2020-01-30T12:17:27+00:00"
+        },
+        {
+            "name": "swaggest/json-diff",
+            "version": "v3.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/json-diff.git",
+                "reference": "bb3e3b4e9d842bb2e48f31ea568d0459968d1d42"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/json-diff/zipball/bb3e3b4e9d842bb2e48f31ea568d0459968d1d42",
+                "reference": "bb3e3b4e9d842bb2e48f31ea568d0459968d1d42",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.23"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonDiff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "JSON diff/rearrange/patch/pointer library for PHP",
+            "support": {
+                "issues": "https://github.com/swaggest/json-diff/issues",
+                "source": "https://github.com/swaggest/json-diff/tree/v3.8.3"
+            },
+            "time": "2021-09-25T22:09:03+00:00"
+        },
+        {
+            "name": "swaggest/json-schema",
+            "version": "v0.12.39",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/php-json-schema.git",
+                "reference": "193ba39cce1ffa2d55ddd5445315e945a63298a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/php-json-schema/zipball/193ba39cce1ffa2d55ddd5445315e945a63298a2",
+                "reference": "193ba39cce1ffa2d55ddd5445315e945a63298a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.4",
+                "phplang/scope-exit": "^1.0",
+                "swaggest/json-diff": "^3.8.2",
+                "symfony/polyfill-mbstring": "^1.19"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.23"
+            },
+            "suggest": {
+                "ext-mbstring": "For better performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "High definition PHP structures with JSON-schema based validation",
+            "support": {
+                "email": "vearutop@gmail.com",
+                "issues": "https://github.com/swaggest/php-json-schema/issues",
+                "source": "https://github.com/swaggest/php-json-schema/tree/v0.12.39"
+            },
+            "time": "2021-10-15T18:12:27+00:00"
         },
         {
             "name": "symfony-cmf/routing",
@@ -17641,6 +17855,7 @@
         "drupal/elasticsearch_connector": 15,
         "drupal/external_entities": 15,
         "drupal/helfi_drupal_tools": 20,
+        "drupal/json_field": 5,
         "drupal/openapi_ui_redoc": 5
     },
     "prefer-stable": true,

--- a/public/modules/custom/helfi_global_navigation/composer.json
+++ b/public/modules/custom/helfi_global_navigation/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "drupal/helfi_global_navigation",
+    "description": "HELfi Global Navigation",
+    "type": "drupal-module",
+    "license": "GPL-2.0-or-later",
+    "minimum-stability": "dev",
+    "require": {
+        "drupal/helfi_api_base": "^2.0 || dev-main",
+        "drupal/json_field": "^1.0@RC",
+        "drupal/readonly_field_widget": "^1.0",
+        "josdejong/jsoneditor": "^5.29"
+    }
+}

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.info.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.info.yml
@@ -1,0 +1,8 @@
+name: 'HELfi global navigation'
+type: module
+core_version_requirement: '^8.9 || ^9'
+dependencies:
+  - helfi_api_base
+  - json_field
+  - text
+  - readonly_field_widget

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.links.menu.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.links.menu.yml
@@ -1,0 +1,5 @@
+entity.global_menu.collection:
+  title: HELfi - Global menus
+  description: View synchronized menus
+  route_name: entity.global_menu.collection
+  parent: helfi_api_base.integrations

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.links.task.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.links.task.yml
@@ -1,0 +1,4 @@
+global_menu.content_list:
+  title: HELfi - Global menu
+  route_name: entity.global_menu.collection
+  base_route: helfi_api_base.integrations

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityInterface;
+
+function helfi_global_navigation_menu_link_content_update(EntityInterface $entity) {
+  $menu = $entity->getMenuName();
+
+  if($menu === 'main') {
+    $queue = \Drupal::queue('menu_queue');
+    // Menu tree get built when queue executes, no need to hold old items
+    $queue->createQueue();
+    $queue->createItem($menu);
+  }
+
+  return $entity;
+}

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.routing.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.routing.yml
@@ -1,0 +1,14 @@
+helfi_global_navigation.global_menu_list:
+  path: /global-menus
+  defaults:
+    _controller: Drupal\helfi_global_navigation\Controller\MenuController::list
+  methods: ['GET']
+  requirements:
+    _permission: 'access content'
+
+helfi_global_navigation.global_menu_post:
+  path: /global-menus/{id}
+  defaults:
+    _controller: Drupal\helfi_global_navigation\Controller\MenuController::post
+  requirements:
+    _permission: 'access content'

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.services.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.services.yml
@@ -1,0 +1,4 @@
+services:
+  helfi_global_navigation.menu_updater:
+    class: \Drupal\helfi_global_navigation\MenuUpdater
+    arguments: ['@config.factory', '@helfi_api_base.environment_resolver', '@http_client', '@language_manager']

--- a/public/modules/custom/helfi_global_navigation/src/Controller/MenuController.php
+++ b/public/modules/custom/helfi_global_navigation/src/Controller/MenuController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\helfi_global_navigation\Entity\GlobalMenu;
+use GuzzleHttp\json_decode;
+use GuzzleHttp\json_encode;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Controller for global menu entities.
+ */
+class MenuController extends ControllerBase {
+
+  /**
+   * Return all global menu entities.
+   *
+   * @return Symfony\Component\HttpFoundation\JsonResponse
+   *   List of global menu entities.
+   */
+  public function list(): JsonResponse {
+    $menus = array_map(function ($menu) {
+      $menuResponse = [
+        'id' => $menu->id(),
+        'name' => $menu->get('name')->value,
+      ];
+
+      if ($tree = $menu->get('menu_tree')->value) {
+        $menuResponse['tree'] = json_decode($menu->get('menu_tree')->value);
+      }
+
+      return $menuResponse;
+    }, GlobalMenu::loadMultiple());
+
+    return new JsonResponse($menus);
+  }
+
+  /**
+   * Create or update menu entity.
+   *
+   * @return Symfony\Component\HttpFoundation\JsonResponse
+   *   The resulting menu entity.
+   */
+  public function post(string $id, Request $request): JsonResponse {
+    $data = json_decode($request->getContent());
+
+    $existingId = \Drupal::entityQuery('global_menu')
+      ->condition('project', $id)
+      ->range(0, 1)
+      ->execute();
+
+    if (!empty($existingId)) {
+      $existing = GlobalMenu::load(reset($existingId));
+      $existing->name = $data->name;
+      $existing->menu_tree = json_encode($data->menu_tree);
+      $existing->save();
+
+      return new JsonResponse($existing);
+    }
+
+    $menu = GlobalMenu::create([
+      'project' => $id,
+      'name' => $data->name,
+      'menu_tree' => json_encode($data->menu_tree),
+    ]);
+
+    $menu->save();
+
+    return new JsonResponse($menu, 201);
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines global_menu entity class.
+ *
+ * @ContentEntityType(
+ *   id = "global_menu",
+ *   fieldable = FALSE,
+ *   label = @Translation("HELfi Global menu"),
+ *   handlers = {
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "list_builder" = "Drupal\helfi_global_navigation\Entity\Listing\ListBuilder",
+ *     "form" = {
+ *       "default" = "Drupal\helfi_global_navigation\Form\GlobalMenuForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\helfi_global_navigation\Entity\Routing\GlobalMenuRouteProvider"
+ *     }
+ *   },
+ *   base_table = "global_menu",
+ *   data_table = "global_menu_field_data",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid",
+ *     "langcode" = "langcode"
+ *   },
+ *   translatable = TRUE,
+ *   admin_permission = "access content",
+ *   links = {
+ *     "canonical" = "/global_menu/{global_menu}",
+ *     "edit-form" = "/admin/content/integrations/global_menu/{global_menu}/edit",
+ *     "collection" = "/admin/content/integrations/global_menu",
+ *     "delete-form" = "/admin/content/integrations/global_menu/{global_menu}/delete"
+ *   }
+ * )
+ */
+class GlobalMenu extends ContentEntityBase implements ContentEntityInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['project'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Project'))
+      ->setSetting('max_length', 50)
+      ->setRequired(TRUE)
+      ->setDisplayOptions('form', [
+        'label' => 'inline',
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Name'))
+      ->setSetting('max_length', 50)
+      ->setRequired(TRUE)
+      ->setDisplayOptions('form', [
+        'label' => 'inline',
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE);
+
+    $fields['menu_tree'] = BaseFieldDefinition::create('json')
+      ->setLabel(new TranslatableMarkup('Menu tree'))
+      ->setDisplayOptions('form', [
+        'type' => 'json_editor',
+      ])
+      ->setReadOnly(TRUE)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    return $fields;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Entity/Listing/ListBuilder.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/Listing/ListBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Entity\Listing;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+
+/**
+ * Provides a list controller to global menu entity types.
+ */
+class ListBuilder extends EntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['id'] = $this->t('ID');
+    $header['project'] = $this->t('Project');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['id'] = $entity->id();
+    $row['project'] = $entity->toLink($entity->get('project')->value);
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDefaultOperations(EntityInterface $entity) {
+    $operations = parent::getDefaultOperations($entity);
+    $destination = $this->redirectDestination->getAsArray();
+    foreach ($operations as $key => $operation) {
+      $operations[$key]['query'] = $destination;
+    }
+    return $operations;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Entity/Routing/GlobalMenuRouteProvider.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/Routing/GlobalMenuRouteProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Entity\Routing;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Provides routes for content entities.
+ *
+ * @see \Drupal\Core\Entity\Routing\AdminHtmlRouteProvider
+ * @see \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider
+ */
+final class GlobalMenuRouteProvider extends AdminHtmlRouteProvider {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRoutes(EntityTypeInterface $entity_type) {
+    $collection = parent::getRoutes($entity_type);
+
+    $route = (new Route('/admin/content/integrations/global_menu/add'))
+      ->addDefaults([
+        '_entity_form' => 'global_menu.default',
+        '_title' => 'Add menu',
+      ])
+      ->setRequirement('_access', 'TRUE');
+    $collection->add('global_menu.add_form', $route);
+
+    return $collection;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Form/GlobalMenuForm.php
+++ b/public/modules/custom/helfi_global_navigation/src/Form/GlobalMenuForm.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form handler for the Example add and edit forms.
+ */
+class GlobalMenuForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    return $form;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/MenuUpdater.php
+++ b/public/modules/custom/helfi_global_navigation/src/MenuUpdater.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation;
+
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\helfi_api_base\Environment\EnvironmentResolver;
+use Drupal\helfi_api_base\Environment\Project;
+use GuzzleHttp\ClientInterface;
+use GuzzlleHttp\json_encode;
+
+/**
+ * Synchronizes global menu.
+ */
+class MenuUpdater {
+  /**
+   * Main menu machine name.
+   */
+  protected const MAIN_MENU = 'main';
+
+  /**
+   * Max depth for menu item synchronization.
+   */
+  protected const MAX_DEPTH = 2;
+
+  /**
+   * Current environment.
+   *
+   * @var string
+   */
+  protected $env;
+
+  /**
+   * Constructs MenuUpdater.
+   */
+  public function __construct(
+    protected ConfigFactory $config,
+    protected EnvironmentResolver $environmentResolver,
+    protected ClientInterface $httpClient,
+    protected LanguageManagerInterface $languageManager
+  ) {
+    $this->env = getenv('APP_ENV');
+  }
+
+  /**
+   * Sends main menu tree to frontpage instance.
+   */
+  public function syncMenu(): void {
+    $currentProject = $this->getCurrentEnvironment();
+
+    // Bail if current environment isn't listed in resolver.
+    if (!$currentProject) {
+      return;
+    }
+
+    $frontpage = $this->environmentResolver->getEnvironment(Project::ETUSIVU, $this->env);
+
+    // Return early if current instance is frontpage.
+    if ($currenProject[$this->env]->getDomain() === $environment->getDomain()) {
+      return;
+    }
+
+    $baseUrl = $frontpage->getUrl($this->languageManager->getCurrentLanguage()->getId());
+    $menuTree = $this->buildMenuTree();
+
+    $url = $baseUrl . '/global-menus/' . $currentProject['id'];
+    try {
+      $options = [
+        'body' => json_encode([
+          'name' => $this->config->get('system.site')->get('name'),
+          'menu_tree' => $menuTree,
+        ]),
+      ];
+
+      // Disable SSL verify in local environment.
+      if ($this->env === 'local') {
+        $options['verify'] = FALSE;
+      }
+
+      $this->httpClient->request('POST', $url, $options);
+    }
+    catch (\Exception $e) {
+
+    }
+  }
+
+  /**
+   * Builds menu tree for synchronization.
+   *
+   * @return array
+   *   The resulting tree.
+   */
+  protected function buildMenuTree(): array {
+    $drupalTree = \Drupal::menuTree()->load(self::MAIN_MENU, new MenuTreeParameters());
+
+    return $this->transformMenuItems($drupalTree);
+  }
+
+  /**
+   * Transform menu items to response format.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeElement[] $menuItems
+   *   Array of menu items.
+   */
+  protected function transformMenuItems(array $menuItems): array {
+    $transformedItems = [];
+
+    foreach ($menuItems as $menuItem) {
+      $menuLink = $menuItem->link;
+      $subTree = $menuItem->subtree;
+
+      $transformedItem = [
+        'name' => $menuLink->getTitle(),
+        'url' => $menuLink->getUrlObject()->setAbsolute(TRUE)->toString(),
+      ];
+
+      if (count($subTree) > 0 && $menuItem->depth < self::MAX_DEPTH) {
+        $transformedItem['sub_tree'] = $this->transformMenuItems($subTree);
+      }
+
+      $transformedItems[] = $transformedItem;
+    }
+
+    return $transformedItems;
+  }
+
+  /**
+   * Determine current project.
+   *
+   * @return array|null
+   *   The resulting environment or null.
+   */
+  protected function getCurrentEnvironment(): array|NULL {
+    $projects = $this->environmentResolver->getProjects();
+    $currentHost = \Drupal::request()->getHost();
+    foreach ($projects as $key => $project) {
+      if ($currentHost === $project[$this->env]->getDomain()) {
+        return [
+          'id' => $key,
+          'project' => $project,
+        ];
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/QueueWorker/MenuQueue.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/QueueWorker/MenuQueue.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+
+/**
+ * Processes menu sync tasks.
+ *
+ * @QueueWorker(
+ *  id = "menu_queue",
+ *  title = @Translation("Queue worker for menu synchronization"),
+ *  cron = {"time" = 15}
+ * )
+ */
+class MenuQueue extends QueueWorkerBase {
+  /**
+   * Menu updater.
+   *
+   * @var \Drupal\helfi_api_base\MenuUpdater
+   */
+  protected $menuUpdater;
+
+  /**
+   * Constructs a new MenuQueue.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->menuUpdater = \Drupal::service('helfi_global_navigation.menu_updater');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $this->menuUpdater->syncMenu();
+  }
+
+}


### PR DESCRIPTION
# [UHF-5843 Global navigation POC](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5843)
Created a POC of global navigation feature.

## What was done
Added POC version of global navigation. Added:
- Custom entity to store global navigations
- Custom controller to create/update them
- Custom queue to handle sending menu data to frontpage instance
- Some supporting composer dependencies

## How to install

- Run `git fetch; git checkout origin/UHF-5843-global-navigation-poc`
- Enable module: `drush en helfi_global_navigation -y`

## How to test
For ease of testing, try commenting out lines 62-64 in `public/modules/custom/helfi_global_navigation/src/MenuUpdater`:
Usually we wouldn't want to sync fronpages' main menu, but it does for testing purposes.

After this:
- [Edit main menu](https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/main)
- Run `drush queue:run menu_queue`.
- [Check that a global menu item was created](https://helfi-etusivu.docker.so/fi/admin/content/integrations/global_menu)
- Try editing the main menu again. Running the queue should update the global menu entity to reflect these changes.

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

