### PR TITLE
Uhf 6037 http wrapper

### DIFF
--- a/public/modules/custom/helfi_global_navigation/assets/schema.json
+++ b/public/modules/custom/helfi_global_navigation/assets/schema.json
@@ -28,7 +28,7 @@
   "$defs": {
     "tree": {
       "type": "object",
-      "required": ["id", "name", "url", "weight"],
+      "required": ["id", "name", "url"],
       "properties": {
         "description": {
           "type": "string"

--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.services.yml
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.services.yml
@@ -7,9 +7,12 @@ services:
   helfi_global_navigation.external_menu_tree_factory:
     class: \Drupal\helfi_global_navigation\ExternalMenuTreeFactory
     arguments: ['@helfi_global_navigation.schema_storage', '@logger.channel.helfi_global_navigation']
+  helfi_global_navigation.global_navigation_service:
+    class: \Drupal\helfi_global_navigation\Service\GlobalNavigationService
+    arguments: ['@cache.default', '@http_client', '@helfi_api_base.environment_resolver', '@language_manager', '@logger.channel.helfi_global_navigation', '@request_stack']
   helfi_global_navigation.external_menu_block_base:
     class: \Drupal\helfi_global_navigation\Plugin\Block\ExternalMenuBlockBase
-    arguments: ['@helfi_global_navigation.external_menu_tree_factory']
+    arguments: ['@helfi_global_navigation.external_menu_tree_factory', '@helfi_global_navigation.global_navigation_service']
   helfi_global_navigation.menu_updater:
     class: \Drupal\helfi_global_navigation\MenuUpdater
-    arguments: ['@config.factory', '@helfi_api_base.environment_resolver', '@http_client', '@language_manager']
+    arguments: ['@config.factory', '@helfi_global_navigation.global_navigation_service']

--- a/public/modules/custom/helfi_global_navigation/src/Controller/MenuController.php
+++ b/public/modules/custom/helfi_global_navigation/src/Controller/MenuController.php
@@ -24,16 +24,9 @@ class MenuController extends ControllerBase {
    */
   public function list(): JsonResponse {
     $menus = array_map(function ($menu) {
-      $menuResponse = [
-        'id' => $menu->id(),
-        'name' => $menu->get('name')->value,
-      ];
-
       if ($tree = $menu->get('menu_tree')->value) {
-        $menuResponse['tree'] = json_decode($menu->get('menu_tree')->value);
+        return json_decode($tree);
       }
-
-      return $menuResponse;
     }, GlobalMenu::loadMultiple());
 
     return new JsonResponse($menus);

--- a/public/modules/custom/helfi_global_navigation/src/ExternalMenuTreeFactory.php
+++ b/public/modules/custom/helfi_global_navigation/src/ExternalMenuTreeFactory.php
@@ -61,7 +61,7 @@ class ExternalMenuTreeFactory {
    *   The resulting menu tree instance.
    */
   public function fromJson(string $json, int $maxDepth):? ExternalMenuTree {
-    $data = json_decode($json);
+    $data = (array) json_decode($json);
     $isValid = $this->validate($data);
 
     if (!$isValid) {

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/Block/ExternalMenuBlockBase.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/Block/ExternalMenuBlockBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\helfi_global_navigation\ExternalMenuTree;
 use Drupal\helfi_global_navigation\ExternalMenuTreeFactory;
+use Drupal\helfi_global_navigation\Service\GlobalNavigationService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,8 +27,10 @@ abstract class ExternalMenuBlockBase extends BlockBase implements ContainerFacto
    *   The plugin implementation definition.
    * @param \Drupal\helfi_global_navigation\ExternalMenuTreeFactory $menuTreeFactory
    *   Factory class for creating an instance of ExternalMenuTree.
+   * @param \Drupal\helfi_global_navigation\Service\GlobalNavigationService $globalNavigationService
+   *   Global navigation service.
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, protected ExternalMenuTreeFactory $menuTreeFactory) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, protected ExternalMenuTreeFactory $menuTreeFactory, protected GlobalNavigationService $globalNavigationService) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
 
@@ -39,7 +42,8 @@ abstract class ExternalMenuBlockBase extends BlockBase implements ContainerFacto
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('helfi_global_navigation.external_menu_tree_factory')
+      $container->get('helfi_global_navigation.external_menu_tree_factory'),
+      $container->get('helfi_global_navigation.global_navigation_service')
     );
   }
 

--- a/public/modules/custom/helfi_global_navigation/src/Service/GlobalNavigationService.php
+++ b/public/modules/custom/helfi_global_navigation/src/Service/GlobalNavigationService.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\helfi_api_base\Environment\Environment;
+use Drupal\helfi_api_base\Environment\EnvironmentResolver;
+use Drupal\helfi_api_base\Environment\Project;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\json_decode;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Service class for global navigation related functions.
+ */
+class GlobalNavigationService implements ContainerInjectionInterface {
+
+  /**
+   * Current project.
+   *
+   * @var array
+   */
+  protected $currentProject;
+
+  /**
+   * Current environment (local/test/prod).
+   *
+   * @var string
+   */
+  protected $env;
+
+  /**
+   * Construct an instance.
+   *
+   * @param Drupal\Core\Cache\CacheBackendInterface $dataCache
+   *   The data cache.
+   * @param GuzzleHttp\ClientInterface $httpClient
+   *   The HTTP client.
+   * @param Drupal\helfi_api_base\Environment\EnvironmentResolver $environmentResolver
+   *   EnvironmentResolver helper class.
+   * @param Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Logger channel.
+   * @param Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   Request stack.
+   */
+  public function __construct(
+    protected CacheBackendInterface $dataCache,
+    protected ClientInterface $httpClient,
+    protected EnvironmentResolver $environmentResolver,
+    protected LanguageManagerInterface $languageManager,
+    protected LoggerInterface $logger,
+    protected RequestStack $requestStack
+  ) {
+    $this->env = getenv('APP_ENV');
+    $this->currentProject = $this->initializeProject();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('cache.default'),
+      $container->get('http_client'),
+      $container->get('helfi_api_base.environment_resolver'),
+      $container->get('language_manager'),
+      $container->get('logger.channel.helfi_global_navigation'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Check if environment is frontpage.
+   *
+   * @param array $environment
+   *   The environment to check.
+   */
+  public function isFrontPage(array $environment): bool {
+    return $this->currentProject[$this->env]->getDomain() === $environment->getDomain();
+  }
+
+  /**
+   * Return current env.
+   *
+   * @return string
+   *   The env.
+   */
+  public function getEnv(): string {
+    return $this->env;
+  }
+
+  /**
+   * Return the current project.
+   *
+   * @return array
+   *   The project
+   */
+  public function getCurrentProject(): array {
+    return $this->currentProject;
+  }
+
+  /**
+   * Check if current instance is frontpage.
+   */
+  public function inFrontPage(): bool {
+    return $this->getCurrentProject()['project'][$this->env]->getDomain() === $this->getFrontPage()->getDomain();
+  }
+
+  /**
+   * Makes a request based on parameters and returns the response.
+   *
+   * @param string $project
+   *   The project or instance to which the request is made.
+   * @param string $method
+   *   Request method.
+   * @param string $endpoint
+   *   The endpoint in the instance.
+   * @param array $options
+   *   Body for requests.
+   *
+   * @return string
+   *   The response body.
+   */
+  public function makeRequest(string $project, string $method, string $endpoint, array $options = []): string {
+    $url = $this->getProjectUrl($project) . $endpoint;
+
+    // Disable SSL verification in local environment.
+    if ($this->env === 'local') {
+      $options['verify'] = FALSE;
+    }
+
+    if ($method === 'GET') {
+      return $this->getContent($url, $options);
+    }
+
+    try {
+      $response = $this->httpClient->request($method, $url, $options);
+      $content = (string) $response->getBody();
+
+      return $content;
+    }
+    catch (\throwable $e) {
+      $this->logger->error('Request failed with error: ' . $e->getMessage());
+
+      return [];
+    }
+  }
+
+  /**
+   * Make a get request and cache results.
+   *
+   * @param string $url
+   *   The url for the request.
+   * @param array $options
+   *   Possible options for the request.
+   *
+   * @return string
+   *   The response body.
+   */
+  public function getContent(string $url, array $options = []): string {
+    if ($data = $this->getFromCache($url)) {
+      return $data;
+    }
+
+    try {
+      $response = $this->httpClient->request('GET', $url, $options);
+      $content = (string) $response->getBody();
+      $this->setCache($url, $content);
+
+      return $content;
+    }
+    catch (\throwable $e) {
+      $this->logger->error('Request failed with error: ' . $e->getMessage());
+
+      return $response;
+    }
+  }
+
+  /**
+   * Gets the cache key for given id.
+   *
+   * @param string $id
+   *   The id.
+   *
+   * @return string
+   *   The cache key.
+   */
+  protected function getCacheKey(string $id): string {
+    $id = preg_replace('/[^a-z0-9_]+/s', '_', $id);
+
+    return sprintf('global-navigation-%s', $id);
+  }
+
+  /**
+   * Gets cached data for given id.
+   *
+   * @param string $id
+   *   The id.
+   *
+   * @return string|null
+   *   The cached data or null.
+   */
+  protected function getFromCache(string $id):? string {
+    $key = $this->getCacheKey($id);
+
+    if (isset($this->data[$key])) {
+      return $this->data[$key];
+    }
+
+    if ($data = $this->dataCache->get($key)) {
+      return $data->data;
+    }
+    return NULL;
+  }
+
+  /**
+   * Sets the cache.
+   *
+   * @param string $id
+   *   The id.
+   * @param mixed $data
+   *   The data.
+   */
+  protected function setCache(string $id, $data): void {
+    $key = $this->getCacheKey($id);
+    $this->dataCache->set($key, $data, $this->getCacheMaxAge(), []);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() : int {
+    return time() + 60 * 60;
+  }
+
+  /**
+   * Return frontpage project.
+   *
+   * @return Drupal\helfi_api_base\Environment\Environment
+   *   The frontpage project.
+   */
+  protected function getFrontPage(): Environment {
+    return $this->environmentResolver->getEnvironment(Project::ETUSIVU, $this->env);
+  }
+
+  /**
+   * Return project's environment-speficif URL with correct language parameter.
+   *
+   * @param string $id
+   *   Project id.
+   *
+   * @return string
+   *   The URL.
+   */
+  protected function getProjectUrl($id) {
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
+    return $this->environmentResolver->getEnvironment($id, $this->env)->getUrl($currentLanguage);
+  }
+
+  /**
+   * Determine current project.
+   *
+   * @return array|null
+   *   The resulting environment or null.
+   */
+  protected function initializeProject(): array|NULL {
+    $projects = $this->environmentResolver->getProjects();
+    $currentHost = $this->requestStack->getCurrentRequest()->getHost();
+    foreach ($projects as $key => $project) {
+      if ($currentHost === $project[$this->env]->getDomain()) {
+        return [
+          'id' => $key,
+          'project' => $project,
+          'url' => $this->getProjectUrl($key),
+        ];
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/src/Service/GlobalNavigationService.php
+++ b/public/modules/custom/helfi_global_navigation/src/Service/GlobalNavigationService.php
@@ -11,7 +11,6 @@ use Drupal\helfi_api_base\Environment\Environment;
 use Drupal\helfi_api_base\Environment\EnvironmentResolver;
 use Drupal\helfi_api_base\Environment\Project;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\json_decode;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;


### PR DESCRIPTION
# [UHF-6037](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6037)
Added a service for making requests to any instance + ease of managing global menu utilities.

## What was done
- Added new service `Drupal\helfi_global_navigation\Service\GlobalMenuService` 
- Made pushed global menus schema-compliant

## How to install

- Checkout branch
- `drush en helfi_global_navigation`

To actually test this, some preliminary stuff that needs to be done:

<details>
<summary>Create `public/modules/custom/helfi_global_navigation/src/Plugin/Block/TestBlock.php` and add 👇 inside it</summary>

```
<?php

namespace Drupal\helfi_global_navigation\Plugin\Block;

use Drupal\helfi_global_navigation\ExternalMenuBlockInterface;
use Drupal\helfi_api_base\Environment\Project;

/**
 * For testing purposes.
 *
 * @Block(
 *   id = "test_block",
 *   admin_label = @Translation("Test"),
 *   category = @Translation("Testing")
 * )
 */
class TestBlock extends ExternalMenuBlockBase implements ExternalMenuBlockInterface {

  /**
   * {@inheritdoc}
   */
  public function getData(): string {
    $data = $this->globalNavigationService->makeRequest(Project::ETUSIVU, 'GET', '/global-menus');
    return $this->globalNavigationService->makeRequest(Project::ETUSIVU, 'GET', '/global-menus');
  }

  /**
   * {@inheritdoc}
   */
  public function maxDepth(): int {
    return 2;
  }

}
```

</details>
 
Edit `public/modules/custom/helfi_global_navigation/src/Service/GlobalNavigationService` and modify `inFrontPage` function (line 112) to always return `false`. 

## How to test
- Open up [main menu management](https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/main). Add or edit links there and save. Make sure the menu's language is undefined.
- Run `drush queue:run menu_queue`. You should get notified in terminal that some queue items have been processed.
- Check that menu has actually been synced in the [administration](https://helfi-etusivu.docker.so/fi/admin/content/integrations/global_menu). There should be one created entity.
- Go [block layout management](https://helfi-etusivu.docker.so/fi/admin/structure/block). Add the newly added TestBlock to the page (content region is easiest to check out). 
- View a page where the block should be visible. The block should render. 
- Check code. Does something seem odd?

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
