### PR TITLE
PLAENH-2: atom id field added

### DIFF
--- a/conf/cmi/core.entity_form_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_form_display.node.news_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -93,6 +94,14 @@ content:
     weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_atomid:
+    type: string_textfield
+    weight: 29
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_content:
     type: paragraphs

--- a/conf/cmi/core.entity_view_display.node.news_item.card_teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.card_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.card_teaser
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -63,6 +64,7 @@ content:
     weight: 4
     region: content
 hidden:
+  field_atomid: true
   field_content: true
   field_lead_in: true
   field_main_image_caption: true

--- a/conf/cmi/core.entity_view_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -28,6 +29,14 @@ targetEntityType: node
 bundle: news_item
 mode: default
 content:
+  field_atomid:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 13
+    region: content
   field_content:
     type: entity_reference_revisions_entity_view
     label: hidden

--- a/conf/cmi/core.entity_view_display.node.news_item.medium_teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.medium_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.medium_teaser
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -52,6 +53,7 @@ content:
     weight: 3
     region: content
 hidden:
+  field_atomid: true
   field_content: true
   field_lead_in: true
   field_main_image: true

--- a/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -66,6 +67,7 @@ content:
     weight: 4
     region: content
 hidden:
+  field_atomid: true
   field_content: true
   field_lead_in: true
   field_main_image_caption: true

--- a/conf/cmi/core.entity_view_display.node.news_item.tiny_teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.tiny_teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.tiny_teaser
+    - field.field.node.news_item.field_atomid
     - field.field.node.news_item.field_content
     - field.field.node.news_item.field_lead_in
     - field.field.node.news_item.field_main_image
@@ -54,6 +55,7 @@ content:
     weight: 2
     region: content
 hidden:
+  field_atomid: true
   field_content: true
   field_lead_in: true
   field_main_image: true

--- a/conf/cmi/field.field.node.news_item.field_atomid.yml
+++ b/conf/cmi/field.field.node.news_item.field_atomid.yml
@@ -1,0 +1,19 @@
+uuid: aa32129d-d5e6-404a-9208-58422ef6b5ea
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_atomid
+    - node.type.news_item
+id: node.news_item.field_atomid
+field_name: field_atomid
+entity_type: node
+bundle: news_item
+label: AtomID
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_atomid.yml
+++ b/conf/cmi/field.storage.node.field_atomid.yml
@@ -1,0 +1,21 @@
+uuid: 7fc90f02-fe9b-42bf-a838-5f9728e4d92f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_atomid
+field_name: field_atomid
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* AtomID field was added to news items so we can handle the migration process

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
