### PR TITLE
UHF-5625 News liftup languages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,9 @@
         "patches": {
             "drupal/core": {
                 "[#2706241] AccessAwareRouter does not respect HTTP method": "https://www.drupal.org/files/issues/2022-02-01/2706241-67.patch"
+            },
+            "drupal/draggableviews": {
+                "Save langcode as part of draggableviews data in order to sort by by weight and language": "patches/draggableviews_language.patch"
             }
         },
         "composer-exit-on-patch-failure": true,

--- a/conf/cmi/block.block.hdbt_subtheme_views_block__news_latest_news.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_views_block__news_latest_news.yml
@@ -24,7 +24,7 @@ settings:
   provider: views
   context_mapping: {  }
   views_label: ''
-  items_per_page: none
+  items_per_page: '5'
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'

--- a/conf/cmi/language/fi/views.view.ordered_news_list.yml
+++ b/conf/cmi/language/fi/views.view.ordered_news_list.yml
@@ -9,6 +9,9 @@ display:
             value: "<p>Järjestä etusivun pääuutis-lohkoon nostetut uutiset haluamaasi järjestykseen</p>\r\n"
             format: full_html
       title: 'Järjestele etusivulle nostetut uutiset'
+      empty:
+        area_text_custom:
+          content: 'Yhtään etusivun uutisvirtaan nostettua uutista ei löytynyt. Voit muokata olemassaolevaa uutista tai luoda uuden uutisen haluamallasi kielellä ja nosta oikean kieliversion uutisvirtaan käyttääksesi tätä ominaisuutta.'
   ordered_news:
     display_title: 'Järjestelty uutislista'
     display_options:

--- a/conf/cmi/language/fi/views.view.ordered_news_list.yml
+++ b/conf/cmi/language/fi/views.view.ordered_news_list.yml
@@ -1,0 +1,14 @@
+label: Uutislista
+description: 'Järjestä etusivulle nostetut uutiset '
+display:
+  default:
+    display_options:
+      header:
+        area:
+          content:
+            value: "<p>Järjestä etusivun pääuutis-lohkoon nostetut uutiset haluamaasi järjestykseen</p>\r\n"
+            format: full_html
+  ordered_news:
+    display_title: 'Järjestelty uutislista'
+    display_options:
+      display_description: 'Järjestä etusivulle nostetut uutiset'

--- a/conf/cmi/language/fi/views.view.ordered_news_list.yml
+++ b/conf/cmi/language/fi/views.view.ordered_news_list.yml
@@ -8,6 +8,7 @@ display:
           content:
             value: "<p>Järjestä etusivun pääuutis-lohkoon nostetut uutiset haluamaasi järjestykseen</p>\r\n"
             format: full_html
+      title: 'Järjestele etusivulle nostetut uutiset'
   ordered_news:
     display_title: 'Järjestelty uutislista'
     display_options:

--- a/conf/cmi/views.view.ordered_news_list.yml
+++ b/conf/cmi/views.view.ordered_news_list.yml
@@ -364,12 +364,12 @@ display:
     position: 1
     display_options:
       display_description: 'Order front page main news'
+      rendering_language: '***LANGUAGE_language_interface***'
       display_extenders: {  }
       path: admin/ordered-news
     cache_metadata:
       max-age: 0
       contexts:
-        - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
         - 'user.node_grants:view'

--- a/conf/cmi/views.view.ordered_news_list.yml
+++ b/conf/cmi/views.view.ordered_news_list.yml
@@ -160,7 +160,7 @@ display:
           entity_field: langcode
           plugin_id: field
           label: 'Translation language'
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -483,21 +483,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  attachment_1:
-    id: attachment_1
-    display_title: Liite
-    display_plugin: attachment
-    position: 2
-    display_options:
-      display_extenders: {  }
-    cache_metadata:
-      max-age: 0
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/conf/cmi/views.view.ordered_news_list.yml
+++ b/conf/cmi/views.view.ordered_news_list.yml
@@ -34,16 +34,34 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: field
-          label: ''
+          label: Title
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
             absolute: false
-            word_boundary: false
-            ellipsis: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
             strip_tags: false
             trim: false
+            preserve_tags: ''
             html: false
           element_type: ''
           element_class: ''
@@ -60,7 +78,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -131,6 +149,72 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+          label: 'Translation language'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: mini
         options:
@@ -183,18 +267,9 @@ display:
           id: weight
           table: draggableviews_structure
           field: weight
-          relationship: none
-          group_type: group
-          admin_label: ''
           plugin_id: draggable_views_sort_default
-          order: ASC
           expose:
-            label: ''
-            field_identifier: ''
-          exposed: false
-          draggable_views_reference: this
-          draggable_views_null_order: after
-          draggable_views_pass_arguments: false
+            field_identifier: weight
       arguments: {  }
       filters:
         status:
@@ -219,6 +294,7 @@ display:
           plugin_id: bundle
           value:
             news_item: news_item
+          group: 1
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -304,6 +380,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
@@ -311,10 +391,48 @@ display:
           row_class: ''
           default_row_class: true
           columns:
+            nid: nid
             title: title
+            draggableviews: draggableviews
+            edit_node: edit_node
+            weight: weight
+            langcode: langcode
           default: '-1'
           info:
+            nid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             title:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            draggableviews:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            weight:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -339,7 +457,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships: {  }
@@ -389,8 +507,29 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      sorts:
+        weight:
+          id: weight
+          table: draggableviews_structure
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: draggable_views_sort_default
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          draggable_views_reference: this
+          draggable_views_null_order: after
+          draggable_views_pass_arguments: false
+      defaults:
+        group_by: false
+        sorts: false
+      group_by: false
       display_description: 'Order front page main news'
-      rendering_language: '***LANGUAGE_language_interface***'
+      rendering_language: '***LANGUAGE_language_content***'
       display_extenders: {  }
       path: admin/ordered-news
     cache_metadata:

--- a/conf/cmi/views.view.ordered_news_list.yml
+++ b/conf/cmi/views.view.ordered_news_list.yml
@@ -166,7 +166,18 @@ display:
       cache:
         type: tag
         options: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are currently no news set to be shown on front pages news feed for this language'
+          tokenize: false
       sorts:
         weight:
           id: weight
@@ -354,6 +365,21 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  attachment_1:
+    id: attachment_1
+    display_title: Liite
+    display_plugin: attachment
+    position: 2
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/conf/cmi/views.view.ordered_news_list.yml
+++ b/conf/cmi/views.view.ordered_news_list.yml
@@ -22,7 +22,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Sort main news'
+      title: 'Sort frontpage main news'
       fields:
         title:
           id: title
@@ -332,7 +332,20 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
-      header: {  }
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: 'Sort news items lifted to front page news block in preferred order.'
+            format: full_html
+          tokenize: false
       footer: {  }
       display_extenders: {  }
     cache_metadata:

--- a/patches/draggableviews_language.patch
+++ b/patches/draggableviews_language.patch
@@ -1,0 +1,28 @@
+diff --git a/draggableviews.module b/draggableviews.module
+index eaba8c8..80d1491 100644
+--- a/draggableviews.module
++++ b/draggableviews.module
+@@ -174,6 +174,7 @@ function draggableviews_views_submit(&$form, FormStateInterface $form_state) {
+ 
+   $connection = Database::getConnection();
+   $transaction = $connection->startTransaction();
++  $langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
+   try {
+     foreach ($input['draggableviews'] as $item) {
+       // Remove old data.
+@@ -182,6 +183,7 @@ function draggableviews_views_submit(&$form, FormStateInterface $form_state) {
+         ->condition('view_display', $view_display)
+         ->condition('args', $view_args)
+         ->condition('entity_id', $item['id'])
++        ->condition('langcode', $langcode)
+         ->execute();
+ 
+       // Add new data.
+@@ -191,6 +193,7 @@ function draggableviews_views_submit(&$form, FormStateInterface $form_state) {
+         'args' => $view_args,
+         'entity_id' => $item['id'],
+         'weight' => $item['weight'],
++        'langcode' => $langcode,
+       ];
+       // Save parent if exists.
+       if (isset($item['parent'])) {

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.info.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.info.yml
@@ -5,5 +5,6 @@ package: Custom
 core_version_requirement: ^9 || ^10
 dependencies:
   - rest
+  - draggableviews
 'interface translation project': helfi_etusivu
 'interface translation server pattern': modules/custom/helfi_etusivu/translations/%language.po

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Database\Database;
+
 /**
  * Implements hook_install().
  */
@@ -131,13 +133,13 @@ function helfi_etusivu_update_9005() : void {
   $moduleHandler = \Drupal::service('module_handler');
 
   if ($moduleHandler->moduleExists('draggableviews')) {
-    $spec = array(
+    $spec = [
       'type' => 'varchar',
       'description' => "language code",
       'length' => 5,
       'not null' => TRUE,
-    );
-    $schema = \Drupal\Core\Database\Database::getConnection()->schema();
+    ];
+    $schema = Database::getConnection()->schema();
     $schema->addField('draggableviews_structure', 'langcode', $spec);
   }
 }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -122,3 +122,22 @@ function helfi_etusivu_update_9004() : void {
     }
   }
 }
+
+/**
+ * Add column to draggable view db table.
+ */
+function helfi_etusivu_update_9005() : void {
+  /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+
+  if ($moduleHandler->moduleExists('draggableviews')) {
+    $spec = array(
+      'type' => 'varchar',
+      'description' => "language code",
+      'length' => 5,
+      'not null' => TRUE,
+    );
+    $schema = \Drupal\Core\Database\Database::getConnection()->schema();
+    $schema->addField('draggableviews_structure', 'langcode', $spec);
+  }
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -28,3 +28,20 @@ function helfi_etusivu_form_node_form_alter(&$form, FormStateInterface $form_sta
   $form['promote']['widget']['#title'] = t('Top news flow', [], ['context' => 'News item promoted field wrapper title']);
   $form['promote']['widget']['#title_display'] = 'above';
 }
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function helfi_etusivu_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
+  if ($view->id() === 'ordered_news_list') {
+    $langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
+    $table = $query->getTableInfo('draggableviews_structure');
+    $table['join']->extra = !$table['join']->extra ? [] : $table['join']->extra;
+
+    $table['join']->extra[] = [
+      'field' => 'langcode',
+      'value' => $langcode,
+      'operator' => '='
+    ];
+  }
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -44,7 +44,7 @@ function helfi_etusivu_views_query_alter(ViewExecutable $view, QueryPluginBase $
       $table['join']->extra[] = [
         'field' => 'langcode',
         'value' => $langcode,
-        'operator' => '='
+        'operator' => '=',
       ];
     }
   }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -33,7 +33,10 @@ function helfi_etusivu_form_node_form_alter(&$form, FormStateInterface $form_sta
  * Implements hook_views_query_alter().
  */
 function helfi_etusivu_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
-  if ($view->id() === 'ordered_news_list') {
+  if (
+    $view->id() === 'ordered_news_list' ||
+    $view->id() === 'frontpage_news'
+  ) {
     $langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
     $table = $query->getTableInfo('draggableviews_structure');
     $table['join']->extra = !$table['join']->extra ? [] : $table['join']->extra;

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -6,6 +6,9 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -32,19 +35,17 @@ function helfi_etusivu_form_node_form_alter(&$form, FormStateInterface $form_sta
 /**
  * Implements hook_views_query_alter().
  */
-function helfi_etusivu_views_query_alter(\Drupal\views\ViewExecutable $view, \Drupal\views\Plugin\views\query\QueryPluginBase $query) {
-  if (
-    $view->id() === 'ordered_news_list' ||
-    $view->id() === 'frontpage_news'
-  ) {
-    $langcode = \Drupal::languageManager()->getCurrentLanguage(\Drupal\Core\Language\LanguageInterface::TYPE_CONTENT)->getId();
+function helfi_etusivu_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if (in_array($view->id(), ['ordered_news_list', 'frontpage_news'])) {
     $table = $query->getTableInfo('draggableviews_structure');
-    $table['join']->extra = !$table['join']->extra ? [] : $table['join']->extra;
-
-    $table['join']->extra[] = [
-      'field' => 'langcode',
-      'value' => $langcode,
-      'operator' => '='
-    ];
+    if (isset($table['join']->extra)) {
+      $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+      $table['join']->extra = !$table['join']->extra ? [] : $table['join']->extra;
+      $table['join']->extra[] = [
+        'field' => 'langcode',
+        'value' => $langcode,
+        'operator' => '='
+      ];
+    }
   }
 }


### PR DESCRIPTION
# [UHF-5625](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5625)

[UHF-5458](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5458) was such a small change that I combined these two tickets to one PR


## What was done
Added language sorting option to draggableviews
Added small tweaks 
- added header to the view
- added empty result -text
- UHF-5458: added single news item's "latest news" block to show 1 less item (max 5)

## How to install
* Check [This closed PR](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/24) OR
* The usual: set the site up by using database from testing environment and dev branch, `git checkout UHF-5625_new_liftup_languages`, `make drush-cim` `make drush-cr`
* After setup, make sure the admin user ui language is set to finnish.

## How to test
Make sure the admin user ui language is set to finnish.
if you are using database from testing environment:
  * Start by saving the news order for both finnish and english `/fi/admin/ordered-news`
    * Save the list for every language at least once 
    * Check the different language versions. The news should (or can) be in different order per language
    * On swedish page, you should see "no result" message instead of list of news. 
  * News liftup block is located in `/fi/testisivu` (pääuutiset)
    * The news shown in the block should match the list in the ordering page. The items should (or can) be in different order per language.

UHF-5458: Go to any single news item's page. Sidebar should have max 5 items under "latest news" block



## Other PRs
* [Original PR #24](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/24)
