### PR TITLE
UHF-5914: Remove improper translation

### DIFF
--- a/public/modules/custom/helfi_news_archive/translations/fi.po
+++ b/public/modules/custom/helfi_news_archive/translations/fi.po
@@ -21,9 +21,6 @@ msgctxt "News archive remove item aria label"
 msgid "Remove item"
 msgstr "Poista valinta"
 
-msgctxt "News archive open combobox aria label"
-msgid "Open the combobox"
-
 msgctxt "News archive topics label"
 msgid "Topics"
 msgstr "Aiheet"

--- a/public/modules/custom/helfi_news_archive/translations/sv.po
+++ b/public/modules/custom/helfi_news_archive/translations/sv.po
@@ -21,9 +21,6 @@ msgctxt "News archive remove item aria label"
 msgid "Remove item"
 msgstr "Töm valda"
 
-msgctxt "News archive open combobox aria label"
-msgid "Open the combobox"
-
 msgctxt "News archive topics label"
 msgid "Topics"
 msgstr "Ämnen"


### PR DESCRIPTION

Remove improper translation from .po files that causes trouble.