### PR TITLE
UHF-X draggableviews config

### DIFF
--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - rest.resource.helfi_global_menu_collection
   module:
+    - draggableviews
     - eu_cookie_compliance
     - helfi_api_base
     - helfi_global_navigation
@@ -21,6 +22,7 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'access draggableviews'
   - 'access openapi api docs'
   - 'access toolbar'
   - 'display eu cookie compliance popup'

--- a/conf/cmi/views.view.news.yml
+++ b/conf/cmi/views.view.news.yml
@@ -459,22 +459,22 @@ display:
     display_options:
       title: 'Latest news'
       sorts:
-        created:
-          id: created
+        published_at:
+          id: published_at
           table: node_field_data
-          field: created
+          field: published_at
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: created
+          entity_field: published_at
           plugin_id: date
           order: DESC
           expose:
             label: ''
             field_identifier: ''
           exposed: false
-          granularity: second
+          granularity: minute
       filters:
         status:
           id: status


### PR DESCRIPTION
Tweaked the configuration:
- Added authenticated user permission to edit draggable view
- Single news item "uusimmat uutiset" block sorted by published on instead of created