### PR TITLE
UHF-6835: elastic exposed port dynamically using ports 9200-9220

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ services:
         soft: -1
         hard: -1
     ports:
-      - 9200:9200
+      - 9200-9220:9200
     networks:
       - internal
       - stonehenge-network


### PR DESCRIPTION
# [UHF-6835](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6835)
Allow running multiple projects with elasticsearch simultaneously.

## What was done
Added port range for elasticsearch to docker compose override 

## How to install
You need 2 environments with elasticsearch to test this one (etusivu+kymp)
* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6835_elastic_port_problem`
  * `docker-compose up --build -d`
  * `make fresh`
* Run `make drush-cr`

## How to test
* after the `...up --build`, outside of the container, say `docker compose ps`
  * You should see elasticsearch container's exposed port between 9200-9220
* Try indexing the news
* Go check the elasticsearch content via browser
  * `localhost:92xx/_search`  (use the port you see in `docker compose ps`)
  * You should see the indexed data
* Set up the other drupal with elasticsearch
  * Do the same steps you've done so far with the other project
  * You should be able to setup the project and have 2 different elasticsearches running for 2 different projects
  * You should be able to access both elasticsearches with your browser
  * You should be able to index the data in both projects

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/471