### PR TITLE
UHF-6911: Global navigation debug page with template

### DIFF
--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
@@ -10,6 +10,22 @@ declare(strict_types = 1);
 use Drupal\Core\Url;
 
 /**
+ * Implements hook_theme().
+ */
+function helfi_global_navigation_theme() : array {
+  return [
+    'debug_item' => [
+      'variables' => [
+        'id' => NULL,
+        'label' => NULL,
+        'data' => [],
+      ],
+      'template' => 'debug-item--globalmenu',
+    ],
+  ];
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function helfi_global_navigation_theme_suggestions_menu_alter(array &$suggestions, array $variables) : void {

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/DebugDataItem/GlobalMenuEntityStatus.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/DebugDataItem/GlobalMenuEntityStatus.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class GlobalMenuEntityStatus extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+
   /**
    * {@inheritdoc}
    */
@@ -37,7 +38,7 @@ class GlobalMenuEntityStatus extends DebugDataItemPluginBase implements Containe
     foreach ($menus as $menu) {
       $menu_name = $menu->get('project')->value;
 
-      foreach(['fi', 'en', 'sv'] as $langcode) {
+      foreach (['fi', 'en', 'sv'] as $langcode) {
         try {
           $translation = $menu->getTranslation($langcode);
           $data[$menu_name]["{$langcode}_status"] = $translation->get('status')->value ? 1 : 0;

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/DebugDataItem/GlobalMenuEntityStatus.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/DebugDataItem/GlobalMenuEntityStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_global_navigation\Plugin\DebugDataItem;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\helfi_api_base\DebugDataItemPluginBase;
+use Drupal\helfi_global_navigation\Entity\GlobalMenu;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the debug_data_item.
+ *
+ * @DebugDataItem(
+ *   id = "globalmenu",
+ *   label = @Translation("Global menu entity status"),
+ *   description = @Translation("Global menu entity status")
+ * )
+ */
+class GlobalMenuEntityStatus extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(): array {
+    $data = [];
+
+    $menus = GlobalMenu::loadMultiple();
+    foreach ($menus as $menu) {
+      $menu_name = $menu->get('project')->value;
+
+      foreach(['fi', 'en', 'sv'] as $langcode) {
+        try {
+          $translation = $menu->getTranslation($langcode);
+          $data[$menu_name]["{$langcode}_status"] = $translation->get('status')->value ? 1 : 0;
+          $data[$menu_name]["{$langcode}_getId()}_updated"] = $translation->content_translation_changed->value ? date('d.m.Y H:i', (int) $translation->content_translation_changed->value) : 0;
+        }
+        catch (\Exception $e) {
+          $data[$menu_name]["{$langcode}_status"] = 0;
+          $data[$menu_name]["{$langcode}_updated"] = 0;
+        }
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/public/modules/custom/helfi_global_navigation/templates/debug-item--globalmenu.html.twig
+++ b/public/modules/custom/helfi_global_navigation/templates/debug-item--globalmenu.html.twig
@@ -1,0 +1,52 @@
+{#
+/**
+ * To actually show any data from a custom plugin, you *MUST* override this template
+ * with a template called 'debug-item--{{ id }}.html.twig'.
+ *
+ * For example: debug-item--composer.html.twig, where 'composer' is your plugin's ID.
+ *
+ * You can then loop your data with something like this:
+ * {% for item in data.packages %}
+ *    {{ item.name }}
+ *    {{ item.version }}
+ * {% endfor %}
+ *
+ *  Available variables:
+ *  - id: The ID of your plugin
+ *  - label The label of your plugin
+ *  - data:  An array of data returned by your plugin's collect() method.
+ */
+#}
+
+<h2>Global menu</h2>
+<table aria-label="robots table" style="width:auto;">
+    <thead>
+      <tr>
+        <th>Site name</th>
+        <th>FI status</th>
+        <th>FI updated</th>
+        <th>EN status</th>
+        <th>EN updated</th>
+        <th>SV status</th>
+        <th>SV updated</th>
+      </tr>
+    </thead>
+  <tbody>
+  {% for key, value in data %}
+    <tr>
+      <th id="">
+        {{ key }}
+      </th>
+      {% for key2, value2 in value %}
+        <td>
+          <span style="color: {{ color }}">
+           {{ value2 }}
+          </span>
+        </td>
+      {% endfor %}
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+

--- a/public/modules/custom/helfi_global_navigation/templates/debug-item--globalmenu.html.twig
+++ b/public/modules/custom/helfi_global_navigation/templates/debug-item--globalmenu.html.twig
@@ -18,6 +18,7 @@
  */
 #}
 
+{% if data %}
 <h2>Global menu</h2>
 <table aria-label="robots table" style="width:auto;">
     <thead>
@@ -48,5 +49,4 @@
   {% endfor %}
   </tbody>
 </table>
-
-
+{% endif %}


### PR DESCRIPTION
# [UHF-6911](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6911)
Added debug-item to debug page for global navigation

## What was done
Added debug item which shows translation status & translation update datetime for all menu entities+translations

## How to install
* Make sure you have database from testing environment since it already has global navigation entities
* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6911_globa_navagation_debug`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Go to debug page
* You should see all the sites which are currently saved as global navigation entities
  * By translation, "updated at" time and current status
* If you have the other environments' local environment set up you can try:
  * Save the menu in one of the environments
  * you should see change in the debug items list on front page

