### PR TITLE
Updated rss feed pubdate must be RFC 2822 format

### DIFF
--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -779,7 +779,7 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: html_datetime
+            date_format: fallback
             custom_date_format: r
             timezone: ''
           group_column: value

--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -779,8 +779,8 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: fallback
-            custom_date_format: r
+            date_format: custom
+            custom_date_format: 'D, d/m/Y H:i:s O'
             timezone: ''
           group_column: value
           group_columns: {  }

--- a/conf/cmi/views.view.react_news_feed.yml
+++ b/conf/cmi/views.view.react_news_feed.yml
@@ -1654,8 +1654,8 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: fallback
-            custom_date_format: ''
+            date_format: custom
+            custom_date_format: 'D, d/m/Y H:i:s O'
             timezone: UTC
           group_column: value
           group_columns: {  }

--- a/conf/cmi/views.view.react_news_feed.yml
+++ b/conf/cmi/views.view.react_news_feed.yml
@@ -1654,7 +1654,7 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: html_datetime
+            date_format: fallback
             custom_date_format: ''
             timezone: UTC
           group_column: value


### PR DESCRIPTION
Changed pubdate to rfc 2822 format which is the standard date format for rss feed