### PR TITLE
UHF-6930: Fix global menu cache tags

### DIFF
--- a/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_global_navigation\Entity;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityPublishedTrait;
@@ -82,7 +83,7 @@ final class GlobalMenu extends ContentEntityBase implements ContentEntityInterfa
    * {@inheritdoc}
    */
   public function getCacheTags() : array {
-    return parent::getCacheTags() + ['helfi_global_menu_collection'];
+    return Cache::mergeTags(parent::getCacheTags(), ['helfi_global_menu_collection']);
   }
 
   /**


### PR DESCRIPTION
# [UHF-6930](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6930)

## What was done
* Fixed global menu cache tags.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6930-global-navigation-cache-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Open `https://varnish-helfi-etusivu.docker.so/fi/api/v1/global-menu?_format=json`
  * You should see the menu API.
* Go to `/admin/content/integrations/global_menu`
  * Make some changes, e.g. disable some menu entity.
* Refresh the menu API using Varnish.
  * There shouldn't be any changes yet.
* Run `make shell`:
  * Run `drush p:queue-work --no-interaction --finish`
* Refresh the menu API using Varnish.
  * Now it should have been changed.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
