### PR TITLE
UHF-7021: Changed news tags to static

### DIFF
--- a/conf/cmi/core.entity_view_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_view_display.node.news_item.default.yml
@@ -64,7 +64,7 @@ content:
     type: entity_reference_label
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 10
     region: content
@@ -92,7 +92,7 @@ content:
     type: entity_reference_label
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 11
     region: content
@@ -100,7 +100,7 @@ content:
     type: entity_reference_label
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 12
     region: content


### PR DESCRIPTION
# [UHF-7021](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7021)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Config changes to news tags

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-7021-news-tag-fix`
  * `drush cim`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-7021-news-tag-fix`
* Run `drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to some news item page and check that the tags in the bottom are now static and not links
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/437
