### PR TITLE
Uhf 6852 accessibility changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "prefer-stable": true,
     "require": {
         "ext-libxml": "*",
-        "city-of-helsinki/helfi-etusivu-news-search": "0.5.0",
+        "city-of-helsinki/helfi-etusivu-news-search": "0.6.0",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6.7",
         "drupal/consumer_image_styles": "^4.0",
@@ -152,15 +152,15 @@
             "type": "package",
             "package": {
                 "name": "city-of-helsinki/helfi-etusivu-news-search",
-                "version": "0.5.0",
+                "version": "0.6.0",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.5.0/helfi-etusivu-news-search.zip",
+                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.0/helfi-etusivu-news-search.zip",
                     "type": "zip"
                 },
                 "source": {
                     "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
                     "type": "git",
-                    "reference": "0.5.0"
+                    "reference": "0.6.0"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f473e4f47b3d3f3f06c0e877999f7d45",
+    "content-hash": "8348ef60a5d22e9799de35ffd743bb35",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -177,15 +177,15 @@
         },
         {
             "name": "city-of-helsinki/helfi-etusivu-news-search",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
-                "reference": "0.5.0"
+                "reference": "0.6.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.5.0/helfi-etusivu-news-search.zip"
+                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.0/helfi-etusivu-news-search.zip"
             },
             "type": "library"
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       # Optionally, you can add this to your default environments variables to enable or disable
       # xdebug by default (like /etc/environments, ~/.bashrc, or ~/.zshrc).
       XDEBUG_ENABLE: "${XDEBUG_ENABLE:-false}"
+      ELASTIC_PROXY_URL: "${ELASTIC_PROXY_URL}"
       # DOCKERHOST: host.docker.internal
       # Use drush server to run functional tests so we don't have to care about
       # permission issues.

--- a/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
+++ b/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
@@ -1,6 +1,6 @@
 news-archive:
-  version: 0.5.0
+  version: 0.6.0
   js:
-    assets/main.18f9c04f.js: {}
+    assets/main.fdfd33fb.js: {}
   dependencies:
     - core/drupal

--- a/public/modules/custom/helfi_news_archive/helfi_news_archive.services.yml
+++ b/public/modules/custom/helfi_news_archive/helfi_news_archive.services.yml
@@ -1,0 +1,3 @@
+services:
+  Drupal\helfi_news_archive\Plugin\Block:
+    arguments: ['@config.factory']

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -16,3 +16,6 @@ if (getenv('ELASTICSEARCH_URL')) {
     $config['elasticsearch_connector.cluster.news']['options']['password'] = getenv('ELASTIC_PASSWORD');
   }
 }
+
+// Elastic proxy URL.
+$config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_URL');

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -103,6 +103,9 @@ function hdbt_subtheme_preprocess_paragraph(array &$variables) {
   }
 }
 
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function hdbt_subtheme_preprocess_page__news(array &$variables) {
   $config = \Drupal::config('elastic_proxy.settings');
   if ($config->get('elastic_proxy_url')) {

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -102,3 +102,10 @@ function hdbt_subtheme_preprocess_paragraph(array &$variables) {
     }
   }
 }
+
+function hdbt_subtheme_preprocess_page__news(array &$variables) {
+  $config = \Drupal::config('elastic_proxy.settings');
+  if ($config->get('elastic_proxy_url')) {
+    $variables['elastic_proxy_url'] = $config->get('elastic_proxy_url');
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--news.html.twig
@@ -12,7 +12,7 @@
     {# Render the main news block in before content. #}
     {{ drupal_entity('block', 'views_block__frontpage_news_main_news', check_access=false) }}
 
-    <div id="helfi-etusivu-news-search" class="block--news-archive"></div>
+    <div id="helfi-etusivu-news-search" class="block--news-archive" data-elastic-proxy-url="{{ elastic_proxy_url }}"></div>
   {% endblock page_before_content %}
 
   {% block page_content %}


### PR DESCRIPTION
# [UHF-6852](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6852)
<!-- What problem does this solve? -->

## What was done
- Changed aria-labels in the news React application
- Added translations to Drupal (via HDBT)

## How to install

* Make sure your instance is up and running on correct branch.
* Run `git checkout origin/UHF-6852-accessibility-changes`
* Run `make build`
* Run `make drush-cr`

Add the ELASTIC_PROXY_URL env variable (if you haven't already): 
* Add this: `ELASTIC_PROXY_URL=https://etusivu-elastic-proxy-dev.agw.arodevtest.hel.fi` to your .env file
* Run `make up` (your app container should restart)
* `make shell` into the container. Run `printenv | grep ELASTIC_PROXY_URL` to verify that the variable is added
* Run `make drush-cr`

## How to test
* Make some selections in the dropdowns
* Check the created pills with inspector. They should have aria-label along the lines: "Remove X from search results"

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs

* React-app: https://etusivu-elastic-proxy-dev.agw.arodevtest.hel.fi
