### PR TITLE
UHF-6852: News app accessibility changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "prefer-stable": true,
     "require": {
         "ext-libxml": "*",
-        "city-of-helsinki/helfi-etusivu-news-search": "0.6.1",
+        "city-of-helsinki/helfi-etusivu-news-search": "0.7.1",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6.7",
         "drupal/consumer_image_styles": "^4.0",
@@ -154,15 +154,15 @@
             "type": "package",
             "package": {
                 "name": "city-of-helsinki/helfi-etusivu-news-search",
-                "version": "0.6.1",
+                "version": "0.7.1",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.1/helfi-etusivu-news-search.zip",
+                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.7.1/helfi-etusivu-news-search.zip",
                     "type": "zip"
                 },
                 "source": {
                     "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
                     "type": "git",
-                    "reference": "0.6.1"
+                    "reference": "0.7.1"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bad87fc19eec07f32bf20e8c45f3f7e",
+    "content-hash": "e9fbfc2b9e356dff3ad5f8aef4f46cd5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -177,15 +177,15 @@
         },
         {
             "name": "city-of-helsinki/helfi-etusivu-news-search",
-            "version": "0.6.1",
+            "version": "0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
-                "reference": "0.6.1"
+                "reference": "0.7.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.1/helfi-etusivu-news-search.zip"
+                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.7.1/helfi-etusivu-news-search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
+++ b/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
@@ -1,6 +1,6 @@
 news-archive:
-  version: 0.6.1
+  version: 0.7.0
   js:
-    assets/main.c8a28098.js: {}
+    assets/main.b09fb1ac.js: {}
   dependencies:
     - core/drupal


### PR DESCRIPTION
# [UHF-6852](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6852)
<!-- What problem does this solve? -->
Made changes to news app to resolve accessilibity issues.

## What was done
<!-- Describe what was done -->
* Changed / added aria-label translations to for better accessibility compliance

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout origin/UHF-6852-accessibility-changes`
  * `make build`
* Make sure you have `ELASTIC_PROXY_URL` -env variable set
  * Add this: `ELASTIC_PROXY_URL=https://etusivu-elastic-proxy-dev.agw.arodevtest.hel.fi` to your .env file
  * Run `make up`. Your app container should restart
  * Run `printenv | grep ELASTIC_PROXY_URL` inside the container. You should see the set env variable.
* Make sure translations are loaded: `drush locale:check && drush locale:update`
* Run `make drush-cr`

## How to test
* Navigate to the news archive page https://helfi-etusivu.docker.so/fi/uutiset
* Make some selections from the dropdowns. The filter pills that appear should have aria-label along the lines of "Remove X from search results"
* Inspect the pagination element:
  * Previous -button and Next -button should have aria-labels along the lines of "Move to next page X"
  * Number buttons should have aria-labels along the lines of "Move to page X"

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

