### PR TITLE
UHF-6960 Front page quicklinks

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/block/block--external-menu-mobile-menu.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--external-menu-mobile-menu.html.twig
@@ -7,8 +7,10 @@
  * used of sub-instance external fallback mobile menu.
  */
 #}
-{% embed "@hdbt/block/block--external-menu-block-fallback.html.twig" %}
-  {% block header_top_navigation %}
-    {{ drupal_entity('block', 'hdbt_subtheme_headertopnavigation')}}
-  {% endblock header_top_navigation %}
-{% endembed %}
+{% set header_top_navigation %}
+  {{ drupal_entity('block', 'hdbt_subtheme_headertopnavigation')}}
+{% endset %}
+
+{% embed "@hdbt/block/block--external-menu-block-fallback.html.twig" with {
+  header_top_navigation_content: header_top_navigation
+} %}{% endembed %}


### PR DESCRIPTION
# [UHF-6960](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6960)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed header top navigation to variable, instead of twig block

## How to install

* Make sure your "Etusivu" instance is up and running on latest `UHF-6960_front_page_quicklinks` branch.
  * `git pull origin UHF-6960_front_page_quicklinks`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-6960_front_page_quicklinks`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the header quicklinks gets rendered in to mobile navigation when exploring the mobile width without JS 
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
