### PR TITLE
UHF-X: Skip custom shareable-image token if the image entity is empty

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -82,6 +82,12 @@ function helfi_etusivu_tokens(
 
         // If main image has an image set, use it as the shareable image.
         $image_entity = $node->field_main_image->entity->field_media_image;
+
+        // Skip current entity if it's empty.
+        if ($image_entity->isEmpty()) {
+          break;
+        }
+
         $image_path = $image_entity->entity->getFileUri();
         $image_uri = $image_style->buildUri($image_path);
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

*  Skip custom shareable-image token if the image entity is empty
