### PR TITLE
UHF-6959: Most read safari fix, increase news archive version to 0.7.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "prefer-stable": true,
     "require": {
         "ext-libxml": "*",
-        "city-of-helsinki/helfi-etusivu-news-search": "0.6.1",
+        "city-of-helsinki/helfi-etusivu-news-search": "^0.7.2",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6.7",
         "drupal/consumer_image_styles": "^4.0",
@@ -153,15 +153,15 @@
             "type": "package",
             "package": {
                 "name": "city-of-helsinki/helfi-etusivu-news-search",
-                "version": "0.6.1",
+                "version": "0.7.2",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.1/helfi-etusivu-news-search.zip",
+                    "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.7.2/helfi-etusivu-news-search.zip",
                     "type": "zip"
                 },
                 "source": {
                     "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
                     "type": "git",
-                    "reference": "0.6.1"
+                    "reference": "0.7.2"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00e25f181d5e88abcf911d261a25eb31",
+    "content-hash": "a5cba5f24cc2be556f11623c26cff6fc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -177,15 +177,15 @@
         },
         {
             "name": "city-of-helsinki/helfi-etusivu-news-search",
-            "version": "0.6.1",
+            "version": "0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search",
-                "reference": "0.6.1"
+                "reference": "0.7.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.6.1/helfi-etusivu-news-search.zip"
+                "url": "https://github.com/City-of-Helsinki/helfi-etusivu-news-search/releases/download/0.7.2/helfi-etusivu-news-search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
+++ b/public/modules/custom/helfi_news_archive/helfi_news_archive.libraries.yml
@@ -1,6 +1,6 @@
 news-archive:
-  version: 0.6.1
+  version: 0.7.2
   js:
-    assets/main.c8a28098.js: {}
+    assets/main.8ae1f167.js: {}
   dependencies:
     - core/drupal


### PR DESCRIPTION
# [UHF-6959](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6959)
<!-- What problem does this solve? -->
Fixes most read section safari issue 
## What was done
<!-- Describe what was done -->

* Updated news archive version

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-6959-most-read-safari`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works by visiting https://helfi-etusivu.docker.so/en/news with safari browser
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
