### PR TITLE
UHF-X disable news migration module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -61,7 +61,6 @@ module:
   helfi_media: 0
   helfi_media_map: 0
   helfi_media_map_config: 0
-  helfi_migration: 0
   helfi_navigation: 0
   helfi_news_archive: 0
   helfi_news_item: 0
@@ -94,7 +93,6 @@ module:
   metatag_open_graph: 0
   metatag_twitter_cards: 0
   migrate: 0
-  migrate_plus: 0
   mysql: 0
   node: 0
   oembed_providers: 0


### PR DESCRIPTION
News migration was one-use module. disable it for future deletion