### PR TITLE
UHF-6257: Max depth filter for Global menu endpoints

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=public/modules/custom/**/tests/**

--- a/documentation/menu.md
+++ b/documentation/menu.md
@@ -18,7 +18,7 @@ Allows you to update/retrieve all or instance specific main-navigations.
 
 Get main menu links for individual instance:
 
-- `GET https://www.hel.fi/{langcode}/api/v1/global-menu/{id}`. 
+- `GET https://www.hel.fi/{langcode}/api/v1/global-menu/{id}`.
 
 Get all available main menus:
 - `GET https://www.hel.fi/{langcode}/api/v1/global-menu`
@@ -27,6 +27,10 @@ Get all available main menus:
 
 Update or create a main menu:
 - `POST https://www.hel.fi/{langcode}/api/v1/global-menu/{id}`
+
+#### Filters
+
+- `max-depth`: Filters maximum shown depth of `sub_tree` field. For example `GET https://www.hel.fi/{langcode}/api/v1/global-menu?max-depth=5` will show `sub_tree` up to 5 levels.
 
 #### Fields
 

--- a/public/modules/custom/helfi_global_navigation/README.md
+++ b/public/modules/custom/helfi_global_navigation/README.md
@@ -1,6 +1,6 @@
 # Global navigation
 
-Etusivu-instance is the main repository for global menus. It serves global menus to other helfi-instances.
+Etusivu-instance is the main repository for lobal menus. It serves global menus to other helfi-instances.
 
 ## Features
 

--- a/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/GlobalMenu.php
@@ -160,7 +160,7 @@ final class GlobalMenu extends ContentEntityBase implements ContentEntityInterfa
    */
   public function setMenuTree(mixed $tree) : self {
     if (is_object($tree)) {
-      $tree = \GuzzleHttp\json_encode($tree);
+      $tree = \json_encode($tree, flags: JSON_THROW_ON_ERROR);
     }
     $this->set('menu_tree', $tree);
     return $this;
@@ -186,14 +186,14 @@ final class GlobalMenu extends ContentEntityBase implements ContentEntityInterfa
    * @param bool $associative
    *   Return as associative array instead of object.
    *
-   * @return object|array
+   * @return object|null
    *   Menu tree.
    */
-  public function getMenuTree(bool $associative = FALSE): object|array {
+  public function getMenuTree(bool $associative = FALSE): ? object {
     if ($menu_tree = $this->get('menu_tree')->value) {
-      return json_decode($menu_tree, $associative);
+      return \json_decode($menu_tree, $associative, flags: JSON_THROW_ON_ERROR);
     }
-    return [];
+    return NULL;
   }
 
 }

--- a/public/modules/custom/helfi_global_navigation/src/Entity/Storage/GlobalMenuStorage.php
+++ b/public/modules/custom/helfi_global_navigation/src/Entity/Storage/GlobalMenuStorage.php
@@ -58,8 +58,6 @@ final class GlobalMenuStorage extends SqlContentEntityStorage {
    */
   public function loadMultipleSorted(
     array $conditions = [],
-    string $field = 'weight',
-    string $direction = 'ASC',
     bool $forceCurrentLanguage = TRUE,
   ) : array {
     $query = $this->getQuery()
@@ -74,7 +72,9 @@ final class GlobalMenuStorage extends SqlContentEntityStorage {
     foreach ($conditions as $key => $value) {
       $query->condition($key, $value, '=');
     }
-    $query->sort($field, $direction);
+    // Sort by weight and then by project name.
+    $query->sort('weight')
+      ->sort('name');
 
     $ids = $query->execute();
 

--- a/public/modules/custom/helfi_global_navigation/src/Normalizer/MenuTreeNormalizer.php
+++ b/public/modules/custom/helfi_global_navigation/src/Normalizer/MenuTreeNormalizer.php
@@ -34,9 +34,10 @@ final class MenuTreeNormalizer extends ContentEntityNormalizer {
     $attributes = parent::normalize($entity, $format, $context);
 
     if (isset($attributes['menu_tree'])) {
-      $attributes['menu_tree'] = array_map(function (array $value) {
-        return \GuzzleHttp\json_decode($value['value']);
-      }, $attributes['menu_tree']);
+      $attributes['menu_tree'] = array_map(
+        fn (array $value) => \json_decode($value['value'], flags: JSON_THROW_ON_ERROR),
+        $attributes['menu_tree']
+      );
     }
 
     return $attributes;

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenu.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenu.php
@@ -4,9 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_global_navigation\Plugin\rest\resource;
 
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityStorageException;
-use Drupal\Core\Routing\AccessAwareRouterInterface;
 use Drupal\helfi_global_navigation\Entity\GlobalMenu as GlobalMenuEntity;
 use Drupal\rest\ModifiedResourceResponse;
 use Drupal\rest\ResourceResponse;
@@ -70,7 +68,6 @@ final class GlobalMenu extends GlobalMenuResourceBase {
    *   The response.
    */
   public function get(Request $request) : ResourceResponse {
-    $cacheableMetadata = new CacheableMetadata();
     $langcode = $this->getCurrentLanguageId();
     $entity = $this->getRequestEntity($request);
 
@@ -84,9 +81,10 @@ final class GlobalMenu extends GlobalMenuResourceBase {
       throw new AccessDeniedHttpException();
     }
     $this->assertPermission($translation, 'view');
+    $translation = $this->processEntityFilters($translation, $request);
 
-    $cacheableMetadata->addCacheableDependency($translation)
-      ->addCacheableDependency($request->attributes->get(AccessAwareRouterInterface::ACCESS_RESULT));
+    $cacheableMetadata = $this->getCacheableMetaData($request);
+    $cacheableMetadata->addCacheableDependency($translation);
 
     return (new ResourceResponse($translation, 200))
       ->addCacheableDependency($cacheableMetadata);

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuCollection.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuCollection.php
@@ -36,9 +36,7 @@ final class GlobalMenuCollection extends GlobalMenuResourceBase {
       $cacheableMetadata->addCacheableDependency($entity);
 
       return $this->processEntityFilters($entity, $request);
-    }, $this->storage->loadMultipleSorted([
-      'status' => 1,
-    ]));
+    }, $this->storage->loadMultipleSorted(['status' => 1]));
     $response = new ResourceResponse($entities, 200);
     $response->addCacheableDependency($cacheableMetadata);
 

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuCollection.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuCollection.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_global_navigation\Plugin\rest\resource;
 
-use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Routing\AccessAwareRouterInterface;
 use Drupal\helfi_global_navigation\Entity\GlobalMenu;
 use Drupal\rest\ResourceResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,14 +29,13 @@ final class GlobalMenuCollection extends GlobalMenuResourceBase {
    */
   public function get(Request $request): ResourceResponse {
     $langcode = $this->getCurrentLanguageId();
-    $cacheableMetadata = (new CacheableMetadata())
-      ->addCacheableDependency($request->attributes->get(AccessAwareRouterInterface::ACCESS_RESULT));
+    $cacheableMetadata = $this->getCacheableMetaData($request);
 
-    $entities = array_map(function (GlobalMenu $entity) use ($cacheableMetadata, $langcode) : GlobalMenu {
+    $entities = array_map(function (GlobalMenu $entity) use ($cacheableMetadata, $langcode, $request) : GlobalMenu {
       $entity = $entity->getTranslation($langcode);
       $cacheableMetadata->addCacheableDependency($entity);
 
-      return $entity;
+      return $this->processEntityFilters($entity, $request);
     }, $this->storage->loadMultipleSorted([
       'status' => 1,
     ]));

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
@@ -81,7 +81,7 @@ abstract class GlobalMenuResourceBase extends MenuResourceBase {
    *
    * @param int $maxDepth
    *   The max depth.
-   * @param \stdClass $menuTree
+   * @param object $menuTree
    *   The menu tree to parse.
    * @param int $currentDepth
    *   The current depth.
@@ -89,7 +89,7 @@ abstract class GlobalMenuResourceBase extends MenuResourceBase {
    * @return object
    *   The parsed menu tree.
    */
-  protected function parseMaxDepth(int $maxDepth, \stdClass $menuTree, int $currentDepth = 0) : \stdClass {
+  protected function parseMaxDepth(int $maxDepth, object $menuTree, int $currentDepth = 0) : object {
     $currentDepth = $currentDepth + 1;
 
     foreach ($menuTree->sub_tree as $delta => $tree) {

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
@@ -4,8 +4,12 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_global_navigation\Plugin\rest\resource;
 
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Routing\AccessAwareRouterInterface;
+use Drupal\helfi_global_navigation\Entity\GlobalMenu as GlobalMenuEntity;
 use Drupal\helfi_global_navigation\Entity\Storage\GlobalMenuStorage;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A base class for global menu resources.
@@ -32,6 +36,70 @@ abstract class GlobalMenuResourceBase extends MenuResourceBase {
     $instance->storage = $container->get('entity_type.manager')->getStorage('global_menu');
 
     return $instance;
+  }
+
+  /**
+   * Constructs a new cacheable metadata object with default values.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Drupal\Core\Cache\CacheableMetadata
+   *   The cacheable metadata.
+   */
+  protected function getCacheableMetaData(Request $request) : CacheableMetadata {
+    return (new CacheableMetadata())
+      ->addCacheableDependency($request->attributes->get(AccessAwareRouterInterface::ACCESS_RESULT))
+      ->addCacheContexts(['url.query_args']);
+  }
+
+  /**
+   * Processes the given entity against request filters.
+   *
+   * @param \Drupal\helfi_global_navigation\Entity\GlobalMenu $entity
+   *   The entity to process.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Drupal\helfi_global_navigation\Entity\GlobalMenu
+   *   The processed entity.
+   */
+  protected function processEntityFilters(GlobalMenuEntity $entity, Request $request) : GlobalMenuEntity {
+    $menuTree = $entity->getMenuTree();
+
+    if ($maxDepth = $request->query->get('max-depth')) {
+      $this->parseMaxDepth((int) $maxDepth, $menuTree);
+    }
+    // Override the default menu tree after filters.
+    $entity->setMenuTree($menuTree);
+
+    return $entity;
+  }
+
+  /**
+   * Filters menu tree to given maximum depth.
+   *
+   * @param int $maxDepth
+   *   The max depth.
+   * @param \stdClass $menuTree
+   *   The menu tree to parse.
+   * @param int $currentDepth
+   *   The current depth.
+   *
+   * @return object
+   *   The parsed menu tree.
+   */
+  protected function parseMaxDepth(int $maxDepth, \stdClass $menuTree, int $currentDepth = 0) : \stdClass {
+    $currentDepth = $currentDepth + 1;
+
+    foreach ($menuTree->sub_tree as $delta => $tree) {
+      $menuTree->sub_tree[$delta] = $this->parseMaxDepth($maxDepth, $tree, $currentDepth);
+
+      if ($currentDepth >= $maxDepth) {
+        unset($menuTree->sub_tree[$delta]);
+      }
+    }
+    return $menuTree;
   }
 
 }

--- a/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
+++ b/public/modules/custom/helfi_global_navigation/src/Plugin/rest/resource/GlobalMenuResourceBase.php
@@ -67,12 +67,11 @@ abstract class GlobalMenuResourceBase extends MenuResourceBase {
   protected function processEntityFilters(GlobalMenuEntity $entity, Request $request) : GlobalMenuEntity {
     $menuTree = $entity->getMenuTree();
 
-    if ($maxDepth = $request->query->get('max-depth')) {
+    if ($menuTree && $maxDepth = $request->query->get('max-depth')) {
       $this->parseMaxDepth((int) $maxDepth, $menuTree);
+      // Override the default menu tree after filters.
+      $entity->setMenuTree($menuTree);
     }
-    // Override the default menu tree after filters.
-    $entity->setMenuTree($menuTree);
-
     return $entity;
   }
 
@@ -92,10 +91,13 @@ abstract class GlobalMenuResourceBase extends MenuResourceBase {
   protected function parseMaxDepth(int $maxDepth, object $menuTree, int $currentDepth = 0) : object {
     $currentDepth = $currentDepth + 1;
 
+    if (!isset($menuTree->sub_tree)) {
+      $menuTree->sub_tree = [];
+    }
     foreach ($menuTree->sub_tree as $delta => $tree) {
       $menuTree->sub_tree[$delta] = $this->parseMaxDepth($maxDepth, $tree, $currentDepth);
 
-      if ($currentDepth >= $maxDepth) {
+      if ($currentDepth >= $maxDepth && isset($menuTree)) {
         unset($menuTree->sub_tree[$delta]);
       }
     }

--- a/public/modules/custom/helfi_global_navigation/tests/src/Functional/GlobalMenuResourceTest.php
+++ b/public/modules/custom/helfi_global_navigation/tests/src/Functional/GlobalMenuResourceTest.php
@@ -136,8 +136,6 @@ class GlobalMenuResourceTest extends RestBaseTest {
     if ($menu) {
       $entity->setMenuTree(json_encode($menu));
     }
-    $errors = $entity->validate();
-    $this->assertCount(0, $errors);
     $entity->save();
     return $entity;
   }
@@ -172,8 +170,6 @@ class GlobalMenuResourceTest extends RestBaseTest {
     $translation = $entity->addTranslation('fi')
       ->setMenuTree(json_encode($mock['fi']['menu_tree']))
       ->setLabel('Liikenne fi');
-    $errors = $translation->validate();
-    $this->assertCount(0, $errors);
     $translation->save();
 
     // Visit pages as anonymous user to make sure everything is cached per

--- a/public/modules/custom/helfi_global_navigation/tests/src/Functional/GlobalMenuResourceTest.php
+++ b/public/modules/custom/helfi_global_navigation/tests/src/Functional/GlobalMenuResourceTest.php
@@ -36,12 +36,34 @@ class GlobalMenuResourceTest extends RestBaseTest {
           'sub_tree' => [
             [
               'id' => 'menu_link_content:7c9ddcc2-4d07-4785-8940-046b4cb85fb4',
-              'name' => 'Pysäköinti fi',
+              'name' => 'Depth 2 fi',
               'parentId' => 'base:liikenne',
-              'url' => 'https://localhost',
+              'url' => 'https://localhost/fi/2',
               'external' => FALSE,
-              'hasItems' => FALSE,
+              'hasItems' => TRUE,
               'weight' => 0,
+              'sub_tree' => [
+                [
+                  'id' => 'menu_link_content:de6409aa-c620-4327-90f4-127176f209b2',
+                  'name' => 'Depth 3 fi',
+                  'parentId' => 'menu_link_content:7c9ddcc2-4d07-4785-8940-046b4cb85fb4',
+                  'url' => 'https://localhost/fi/3',
+                  'external' => FALSE,
+                  'hasItems' => TRUE,
+                  'weight' => 0,
+                  'sub_tree' => [
+                    [
+                      'id' => 'menu_link_content:8a28fc72-b10e-49f1-860f-e0967ef2fe0a',
+                      'name' => 'Depth 4 fi',
+                      'parentId' => 'menu_link_content:de6409aa-c620-4327-90f4-127176f209b2',
+                      'url' => 'https://localhost/fi/4',
+                      'external' => FALSE,
+                      'hasItems' => FALSE,
+                      'weight' => 0,
+                    ],
+                  ],
+                ],
+              ],
             ],
           ],
         ],
@@ -57,12 +79,34 @@ class GlobalMenuResourceTest extends RestBaseTest {
           'sub_tree' => [
             [
               'id' => 'menu_link_content:7c9ddcc2-4d07-4785-8940-046b4cb85fb4',
-              'name' => 'Pysäköinti en',
+              'name' => 'Depth 2 en',
               'parentId' => 'base:liikenne',
-              'url' => 'https://localhost',
+              'url' => 'https://localhost/en/2',
               'external' => FALSE,
-              'hasItems' => FALSE,
+              'hasItems' => TRUE,
               'weight' => 0,
+              'sub_tree' => [
+                [
+                  'id' => 'menu_link_content:de6409aa-c620-4327-90f4-127176f209b2',
+                  'name' => 'Depth 3 en',
+                  'parentId' => 'menu_link_content:7c9ddcc2-4d07-4785-8940-046b4cb85fb4',
+                  'url' => 'https://localhost/en/3',
+                  'external' => FALSE,
+                  'hasItems' => TRUE,
+                  'weight' => 0,
+                  'sub_tree' => [
+                    [
+                      'id' => 'menu_link_content:8a28fc72-b10e-49f1-860f-e0967ef2fe0a',
+                      'name' => 'Depth 4 en',
+                      'parentId' => 'menu_link_content:de6409aa-c620-4327-90f4-127176f209b2',
+                      'url' => 'https://localhost/en/4',
+                      'external' => FALSE,
+                      'hasItems' => FALSE,
+                      'weight' => 0,
+                    ],
+                  ],
+                ],
+              ],
             ],
           ],
         ],
@@ -87,8 +131,13 @@ class GlobalMenuResourceTest extends RestBaseTest {
     $entity = $this->storage
       ->createById($id)
       ->set('langcode', 'en')
-      ->setMenuTree($menu)
       ->setLabel($projectName);
+
+    if ($menu) {
+      $entity->setMenuTree(json_encode($menu));
+    }
+    $errors = $entity->validate();
+    $this->assertCount(0, $errors);
     $entity->save();
     return $entity;
   }
@@ -98,7 +147,7 @@ class GlobalMenuResourceTest extends RestBaseTest {
    */
   public function testGetPermissions() : void {
     $this->drupalLogin($this->setUpCurrentUser());
-    $this->createGlobalMenu('liikenne', 'Liikenne', []);
+    $this->createGlobalMenu('liikenne', 'Liikenne');
 
     // Test individual entity.
     $this->drupalGet('/api/v1/global-menu/liikenne');
@@ -118,14 +167,14 @@ class GlobalMenuResourceTest extends RestBaseTest {
    * Tests GET method.
    */
   public function testGetRoutes() : void {
-    $this->createGlobalMenu('liikenne', 'Liikenne en', [])
-      ->addTranslation('fi')
-      ->setLabel('Liikenne fi')
-      ->save();
-    $this->createGlobalMenu('terveys', 'Terveys en', [])
-      ->addTranslation('fi')
-      ->setLabel('Terveys fi')
-      ->save();
+    $mock = $this->getMockJson();
+    $entity = $this->createGlobalMenu('liikenne', 'Liikenne en', $mock['en']['menu_tree']);
+    $translation = $entity->addTranslation('fi')
+      ->setMenuTree(json_encode($mock['fi']['menu_tree']))
+      ->setLabel('Liikenne fi');
+    $errors = $translation->validate();
+    $this->assertCount(0, $errors);
+    $translation->save();
 
     // Visit pages as anonymous user to make sure everything is cached per
     // permissions.
@@ -133,9 +182,7 @@ class GlobalMenuResourceTest extends RestBaseTest {
       $this->drupalGet('/api/v1/global-menu', ['language' => $this->getLanguage($langcode)]);
       $this->assertSession()->statusCodeEquals(HttpResponse::HTTP_UNAUTHORIZED);
 
-      foreach (['liikenne', 'terveys'] as $id) {
-        $this->drupalGet('/api/v1/global-menu/' . $id, ['language' => $this->getLanguage($langcode)]);
-      }
+      $this->drupalGet('/api/v1/global-menu/liikenne', ['language' => $this->getLanguage($langcode)]);
       $this->assertSession()->statusCodeEquals(HttpResponse::HTTP_UNAUTHORIZED);
     }
 
@@ -152,28 +199,76 @@ class GlobalMenuResourceTest extends RestBaseTest {
       $this->assertCacheTags([
         'config:rest.resource.helfi_global_menu_collection',
         'global_menu:liikenne',
-        'global_menu:terveys',
       ]);
-
+      $this->assertCacheContext('url.query_args');
       $this->assertSession()->statusCodeEquals(HttpResponse::HTTP_OK);
 
-      foreach (['liikenne', 'terveys'] as $id) {
-        $expectedLabel = ucfirst($id) . ' ' . $langcode;
-        $this->assertEquals($id, $collectionData->{$id}->project[0]->value);
-        $this->assertEquals($expectedLabel, $collectionData->{$id}->name[0]->value);
+      $this->assertEquals('liikenne', $collectionData->liikenne->project[0]->value);
+      $this->assertEquals('Liikenne ' . $langcode, $collectionData->liikenne->name[0]->value);
 
-        $this->drupalGet('/api/v1/global-menu/' . $id, ['language' => $this->getLanguage($langcode)]);
-        $this->assertCacheTags([
-          'config:rest.resource.helfi_global_menu',
-          'global_menu:' . $id,
+      $this->drupalGet('/api/v1/global-menu/liikenne', ['language' => $this->getLanguage($langcode)]);
+      $this->assertCacheTags([
+        'config:rest.resource.helfi_global_menu',
+        'global_menu:liikenne',
+      ]);
+      $this->assertCacheContext('url.query_args');
+
+      $response = $this->getSession()->getPage()->getContent();
+      $data = json_decode($response);
+      $this->assertSession()->statusCodeEquals(HttpResponse::HTTP_OK);
+      $this->assertEquals('liikenne', $data->project[0]->value);
+      $this->assertEquals('Liikenne ' . $langcode, $data->name[0]->value);
+    }
+
+    // Test depth filter.
+    foreach (['en', 'fi'] as $langcode) {
+      for ($i = 1; $i <= 3; $i++) {
+        $this->drupalGet('/api/v1/global-menu', [
+          'language' => $this->getLanguage($langcode),
+          'query' => ['max-depth' => $i],
         ]);
         $response = $this->getSession()->getPage()->getContent();
         $data = json_decode($response);
-        $this->assertSession()->statusCodeEquals(HttpResponse::HTTP_OK);
-        $this->assertEquals($id, $data->project[0]->value);
-        $this->assertEquals($expectedLabel, $data->name[0]->value);
+
+        // Except all levels shown when max depth is set to 0, otherwise
+        // show up until defined depth.
+        $this->assertMaxDepth($i, $data->liikenne->menu_tree[0]);
       }
     }
+  }
+
+  /**
+   * Parses max depth for given menu tree.
+   *
+   * @param object $data
+   *   The data to parse.
+   * @param int $currentDepth
+   *   The current depth.
+   *
+   * @return int
+   *   The current depth.
+   */
+  private function calculateMaxDepth(object $data, int $currentDepth = 0) : int {
+    $currentDepth = $currentDepth + 1;
+
+    foreach ($data->sub_tree as $tree) {
+      $currentDepth = $this->calculateMaxDepth($tree, $currentDepth);
+    }
+    return $currentDepth;
+  }
+
+  /**
+   * Asserts menu tree's maximum depth.
+   *
+   * @param int $expectedDepth
+   *   The expected maximum depth.
+   * @param object $data
+   *   The menu tree to parse.
+   */
+  private function assertMaxDepth(int $expectedDepth, object $data) : void {
+    $depth = $this->calculateMaxDepth($data);
+
+    $this->assertEquals($expectedDepth, $depth);
   }
 
   /**


### PR DESCRIPTION
# [UHF-6257](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6257)
<!-- What problem does this solve? -->

## What was done
Added max depth filter to Global menu REST-endpoint.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6257`
  * `drush cr`

## How to test

* [ ] Check that Global menu endpoint can be filtered by `max-depth=X` filter. For example `/fi/api/v1/global-menu?max-depth=5` should only show `menu_tree` up to 5 levels.

