### PR TITLE
UHF-7411: Remove eu_cookie_compliance categories from config ignore

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,6 +1,5 @@
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 ignored_config_entities:
-  - 'eu_cookie_compliance.cookie_category*'
   - hdbt_admin_tools.site_settings
   - 'system.site:page.front'


### PR DESCRIPTION
# [UHF-7411](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7411)

## What was done
* Removed eu_cookie_compliance categories from config ignore. The category config files were already up to date.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout UHF-7411-cookie-category-config`
  * `make fresh`
* Run `make drush-cr`

## How to test
* First, check the current cookie settings page (`/cookie-information-and-settings`) at the test environment.
  * You will notice there is only one category visible, so it's not correct.
* Then, check the same page at your local environment after taking the db from test (`make fresh` above).
  * Now all the categories should be visible with all language versions.
  * You can compare the page to other instance's test environment. They should be identical.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
