### PR TITLE
UHF-7097: Demote over 1 month old news items

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -122,6 +122,7 @@ function helfi_etusivu_cron() {
     ->condition('type', 'news_item')
     ->condition('promote', 1)
     ->condition('created', strtotime('-1 month'), '<')
+    ->range(0, 50)
     ->execute();
 
   $promoted_nodes = \Drupal::entityTypeManager()

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -112,3 +112,25 @@ function helfi_etusivu_tokens(
 
   return $replacements;
 }
+
+/**
+ * Implements hook_cron().
+ */
+function helfi_etusivu_cron() {
+  // Get promoted news_item nodes that are more than one month old.
+  $result = \Drupal::entityQuery('node')
+    ->condition('type', 'news_item')
+    ->condition('promote', 1)
+    ->condition('created', strtotime('-1 month'), '<')
+    ->execute();
+
+  $promoted_nodes = \Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->loadMultiple($result);
+
+  // Remove promotion.
+  foreach ($promoted_nodes as $node) {
+    $node->promote = 0;
+    $node->save();
+  }
+}


### PR DESCRIPTION
# [UHF-7097](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7097)
Removes the "promoted" status from News item nodes that are more than 1 month old.

## What was done
- Implemented  a cron hook that loads promoted news item nodes that have been created over 1 month ago and removes the "promoted" status.

## How to install
1. Set up ETUSIVU instance
2. Checkout this branch: `git checkout UHF-7097_demote_old_news_items`

## How to test
1. Create two (or edit existing) news item nodes, one with "Published on" date more than one month ago from now and the another with less
2. Set "Publish the news item in the top news flow" enabled for both nodes
3. Open or create a page with "Top news" ("Pääuutiset") paragraph and see both created news item notes there
4. Run cron: `drush cron`
5. See the page with the "Top news" paragraph and make sure that the news item node that had been created more than one month ago has been removed from there
