### PR TITLE
Re-enable DrupalTestTraits tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,4 @@ jobs:
         run: |
           composer test-php public/modules/custom
           # Uncomment the line below to run drupal-test-trait tests under tests/src/* folder.
-          # composer test-php tests/
+          composer test-php tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           drush runserver $SIMPLETEST_BASE_URL > /dev/null 2>&1 &
           chromedriver --port=4444 > /dev/null 2>&1 &
           # Uncomment the line below to run 'existing-site-javascript' tests.
-          # chromium-browser --headless --disable-gpu --remote-debugging-port=9222 &
+          chromium-browser --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 &
           # Wait for drush server to start.
           for i in {1..5}; do RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$SIMPLETEST_BASE_URL" || true); if [ "$RESPONSE_CODE" -gt "301" ] || [ "$RESPONSE_CODE" -lt "200" ]; then sleep 2; fi; done
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on: [push]
 name: CI
 env:
   SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
-  SIMPLETEST_BASE_URL: "http://127.0.0.1:8080"
+  SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
   SYMFONY_DEPRECATIONS_HELPER: disabled
   XDEBUG_MODE: off
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on: [push]
 name: CI
 env:
   SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
-  SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
+  SIMPLETEST_BASE_URL: "http://127.0.0.1:8080"
   SYMFONY_DEPRECATIONS_HELPER: disabled
   XDEBUG_MODE: off
 jobs:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
   <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", {"chromeOptions":{"w3c": false }}, "http://127.0.0.1:4444"]'/>
   <env name="DTT_API_OPTIONS" value='{"socketTimeout": 360, "domWaitTimeout": 3600000}' />
   <env name="DTT_API_URL" value="http://127.0.0.1:9222"/>
-  <env name="DTT_BASE_URL" value="http://127.0.0.1:8888"/>
+  <env name="DTT_BASE_URL" value="http://127.0.0.1:8080"/>
 </php>
 <testsuites>
   <testsuite name="unit">


### PR DESCRIPTION
Looks like we've accidentally disabled the DrupalTestTraits runner.