### PR TITLE
UHF-7264: Updated hdbt to latest version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4676,16 +4676,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "4.3.0",
+            "version": "4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573"
+                "reference": "419f78ccd02f71c60b194779beed067f657688b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573",
-                "reference": "c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/419f78ccd02f71c60b194779beed067f657688b0",
+                "reference": "419f78ccd02f71c60b194779beed067f657688b0",
                 "shasum": ""
             },
             "require": {
@@ -4700,10 +4700,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.3.0",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.3.3",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2022-11-16T10:05:53+00:00"
+            "time": "2022-11-24T09:53:50+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -16548,16 +16548,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.18",
+            "version": "9.2.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
                 "shasum": ""
             },
             "require": {
@@ -16613,7 +16613,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
             },
             "funding": [
                 {
@@ -16621,7 +16621,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-27T13:35:33+00:00"
+            "time": "2022-11-18T07:47:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -18775,5 +18775,5 @@
         "ext-libxml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
# [UHF-7264](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7264)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated hdbt to latest version.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7264_fix_empty_tag_issue`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that there is no longer empty tags on news items.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)