### PR TITLE
UHF-7620 rss enclosure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "drupal/redis": "^1.5",
         "drupal/search_api": "^1.23",
         "drupal/stage_file_proxy": "^1.2",
+        "drupal/views_rss": "^2.0@RC",
         "drush/drush": "^10.4",
         "josdejong/jsoneditor": "^5.29",
         "justinrainbow/json-schema": "^5.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60ed6b1a9b733a8c3360672d03cf4909",
+    "content-hash": "dafd58ef89d082a1da727d2851eac5f5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8376,6 +8376,82 @@
             "homepage": "https://www.drupal.org/project/views_infinite_scroll",
             "support": {
                 "source": "https://git.drupalcode.org/project/views_infinite_scroll"
+            }
+        },
+        {
+            "name": "drupal/views_rss",
+            "version": "2.0.0-rc2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/views_rss.git",
+                "reference": "8.x-2.0-rc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/views_rss-8.x-2.0-rc2.zip",
+                "reference": "8.x-2.0-rc2",
+                "shasum": "7b47cd9677dd6aea316aa0fde3b80ce2350773bd"
+            },
+            "require": {
+                "drupal/core": "^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-rc2",
+                    "datestamp": "1661863230",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "alex_b",
+                    "homepage": "https://www.drupal.org/user/53995"
+                },
+                {
+                    "name": "DamienMcKenna",
+                    "homepage": "https://www.drupal.org/user/108450"
+                },
+                {
+                    "name": "David Goode",
+                    "homepage": "https://www.drupal.org/user/291318"
+                },
+                {
+                    "name": "idebr",
+                    "homepage": "https://www.drupal.org/user/1879760"
+                },
+                {
+                    "name": "maciej.zgadzaj",
+                    "homepage": "https://www.drupal.org/user/271491"
+                },
+                {
+                    "name": "MiSc",
+                    "homepage": "https://www.drupal.org/user/382892"
+                },
+                {
+                    "name": "Nate_S",
+                    "homepage": "https://www.drupal.org/user/3531716"
+                },
+                {
+                    "name": "rsoden",
+                    "homepage": "https://www.drupal.org/user/226437"
+                },
+                {
+                    "name": "Will White",
+                    "homepage": "https://www.drupal.org/user/32237"
+                }
+            ],
+            "description": "Extends the possibilites to create RSS with Views",
+            "homepage": "https://www.drupal.org/project/views_rss",
+            "support": {
+                "source": "https://git.drupalcode.org/project/views_rss"
             }
         },
         {
@@ -19757,7 +19833,8 @@
         "drupal/external_entities": 15,
         "drupal/helfi_drupal_tools": 20,
         "drupal/json_field": 5,
-        "drupal/openapi_ui_redoc": 5
+        "drupal/openapi_ui_redoc": 5,
+        "drupal/views_rss": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -145,6 +145,8 @@ module:
   view_unpublished: 0
   views_bulk_edit: 0
   views_bulk_operations: 0
+  views_rss: 0
+  views_rss_core: 0
   views_ui: 0
   pathauto: 1
   content_translation: 10

--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -5,14 +5,17 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.storage.node.field_lead_in
+    - field.storage.node.field_main_image
     - node.type.news_item
     - taxonomy.vocabulary.news_group
     - taxonomy.vocabulary.news_neighbourhoods
     - taxonomy.vocabulary.news_tags
   module:
+    - helfi_etusivu
     - node
     - taxonomy
     - user
+    - views_rss
 id: news_archive
 label: 'News archive'
 module: views
@@ -579,71 +582,6 @@ display:
           text: view
           output_url_as_text: true
           absolute: false
-        title_1:
-          id: title_1
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         name:
           id: name
           table: users_field_data
@@ -833,6 +771,133 @@ display:
             date_format: custom
             custom_date_format: r
             timezone: UTC
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_main_image:
+          id: field_main_image
+          table: node__field_main_image
+          field: field_main_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: rss_enclosure_formatter
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1103,16 +1168,23 @@ display:
           grouping: {  }
           description: feed
       row:
-        type: rss_fields
+        type: views_rss_fields
         options:
-          title_field: title
-          link_field: view_node
-          description_field: field_lead_in
-          creator_field: name
-          date_field: published_at
-          guid_field_options:
-            guid_field: view_node
-            guid_field_is_permalink: true
+          item:
+            core:
+              views_rss_core:
+                title: title
+                link: view_node
+                description: field_lead_in
+                author: name
+                category: ''
+                comments: ''
+                enclosure: field_main_image
+                guid: uuid
+                pubDate: published_at
+            content:
+              views_rss_core:
+                encoded: ''
       defaults:
         access: true
         css_class: false
@@ -1146,6 +1218,7 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_lead_in'
+        - 'config:field.storage.node.field_main_image'
   page_1:
     id: page_1
     display_title: Page

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -134,4 +134,5 @@ function helfi_etusivu_cron() {
     $node->promote = 0;
     $node->save();
   }
+
 }

--- a/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldFormatter/RssEnclosureFormatter.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldFormatter/RssEnclosureFormatter.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\helfi_etusivu\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\media\MediaInterface;
+
+/**
+ * Plugin implementation to get image into enclosure in rss feed.
+ *
+ * @FieldFormatter(
+ *   id = "rss_enclosure_formatter",
+ *   label = @Translation("Rss enclosure formatter"),
+ *   field_types = {
+ *     "entity_reference",
+ *   },
+ * )
+ */
+class RssEnclosureFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      if (
+        $item->entity instanceof MediaInterface &&
+        $item->entity->hasField('field_media_image')
+      ) {
+        $image_style = ImageStyle::load('og_image');
+        $image_entity = $item->entity->field_media_image;
+
+        if ($image_entity && $image_entity->isEmpty()) {
+          break;
+        }
+
+        $image_path = $image_entity->entity->getFileUri();
+        $image_uri = $image_style->buildUri($image_path);
+
+        // Create derivative if necessary.
+        if (!file_exists($image_uri)) {
+          $image_style->createDerivative($image_path, $image_uri);
+        }
+
+        $elements[$delta] = [
+          '#markup' => $image_style->buildUrl($image_path)
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+}

--- a/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldFormatter/RssEnclosureFormatter.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldFormatter/RssEnclosureFormatter.php
@@ -5,7 +5,6 @@ namespace Drupal\helfi_etusivu\Plugin\Field\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\MediaInterface;
 
@@ -48,7 +47,7 @@ class RssEnclosureFormatter extends FormatterBase implements ContainerFactoryPlu
         }
 
         $elements[$delta] = [
-          '#markup' => $image_style->buildUrl($image_path)
+          '#markup' => $image_style->buildUrl($image_path),
         ];
       }
     }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -131,3 +131,43 @@ function hdbt_subtheme_preprocess_page__news(array &$variables) {
     $variables['#attached']['drupalSettings']['helfi_news_archive']['elastic_proxy_url'] = $config->get('elastic_proxy_url');
   }
 }
+
+function hdbt_subtheme_preprocess_views_view_row_rss(&$variables) {
+
+  // Get all necessary data to create the enclosure tag with proper attributes.
+  foreach ($variables['item_elements'] as $key => $element) {
+    if ($element['key'] == 'enclosure') {
+     $enclosure_attributes = $variables['item_elements'][$key]['attributes'];
+    }
+    if ($element['key'] == 'guid') {
+      $guid = (string)$variables['item_elements'][2]['value'];
+      $node = \Drupal::service('entity.repository')->loadEntityByUuid('node', $guid);
+    }
+  }
+
+  if (!$node) {
+    return;
+  }
+
+  // Add attributes to enclosure tag.
+  if (
+    $node->hasField('field_main_image') &&
+    !$node->get('field_main_image')->isEmpty()
+  ) {
+    $image = $node->field_main_image->entity->field_media_image->first();
+    $file = $node->field_main_image->entity->field_media_image->entity;
+
+    $values = [
+      'url' => $enclosure_attributes['url'],
+      'type' => $file ? $file->getMimeType() : '',
+      'size' => $file ? $file->getSize() : '',
+      'alt' => $image ? $image->alt : ' ',
+    ];
+
+    foreach($values as $name => $value) {
+      if ($enclosure_attributes) {
+        $enclosure_attributes->offsetSet($name, $value);
+      }
+    }
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -132,15 +132,17 @@ function hdbt_subtheme_preprocess_page__news(array &$variables) {
   }
 }
 
+/**
+ * Implements hook_preprocess_views_view_row_rss().
+ */
 function hdbt_subtheme_preprocess_views_view_row_rss(&$variables) {
-
   // Get all necessary data to create the enclosure tag with proper attributes.
   foreach ($variables['item_elements'] as $key => $element) {
     if ($element['key'] == 'enclosure') {
-     $enclosure_attributes = $variables['item_elements'][$key]['attributes'];
+      $enclosure_attributes = $variables['item_elements'][$key]['attributes'];
     }
     if ($element['key'] == 'guid') {
-      $guid = (string)$variables['item_elements'][2]['value'];
+      $guid = (string) $variables['item_elements'][$key]['value'];
       $node = \Drupal::service('entity.repository')->loadEntityByUuid('node', $guid);
     }
   }
@@ -164,7 +166,7 @@ function hdbt_subtheme_preprocess_views_view_row_rss(&$variables) {
       'alt' => $image ? $image->alt : ' ',
     ];
 
-    foreach($values as $name => $value) {
+    foreach ($values as $name => $value) {
       if ($enclosure_attributes) {
         $enclosure_attributes->offsetSet($name, $value);
       }


### PR DESCRIPTION
# [UHF-7620](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7620)
Added image with alt-text as "enclosure" -tag in rss feed.

## What was done
Installed views rss which allows adding enclosure tag to rss feed.
Added Field formatter which sets proper image-style url as the enclosure tag url-attribute
Preprocessed the enclosure tag to add type, size and alt-text attributes.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7620_rss_enclosure`
  * `make fresh`
* Run `make drush-cr`

## How to test
If you are using production or testing database, you should already have news which have main image with alt text.
- Edit one of the news.
- Add main image with alt text
- Go to https://helfi-etusivu.docker.so/en/news/rss
- You should see <enclosure> tag with proper attributes (url, size, type, alt)

* [x] Check that this feature works
* [x] Check that code follows our standards
