### PR TITLE
UHF-7951: Fixed shareable-image token

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -95,7 +95,7 @@ function helfi_etusivu_tokens(
         if (!file_exists($image_uri)) {
           $image_style->createDerivative($image_path, $image_uri);
         }
-        $replacements[$original] = $image_style->buildUri($image_path);
+        $replacements[$original] = $image_style->buildUrl($image_path);
       }
     }
   }


### PR DESCRIPTION
# [UHF-7951](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7951)
<!-- What problem does this solve? -->

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7951`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add main image to news item
* [x] Check that twitter and og images are absolute URls to image style image. For example `https://helfi-etusivu.docker.so/etusivu-assets/sites/default/files/styles/og_image/public/18240979_v748-toon-103.jpg?h=770552a7&amp;itok=5dzi3Tnl`.


[UHF-7951]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ