### PR TITLE
UHF-8060: Get rid of duplicates in "of interest" listing

### DIFF
--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.card_teaser
     - core.entity_view_mode.node.medium_teaser
-    - core.entity_view_mode.node.teaser
     - field.storage.node.field_main_image
     - field.storage.node.field_news_groups
     - field.storage.node.field_news_item_tags
@@ -1156,6 +1155,73 @@ display:
           table: node__field_news_item_tags
           field: field_news_item_tags
           plugin_id: field
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns:
+            entity_id: entity_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       empty: {  }
       sorts:
         published_at:
@@ -1330,11 +1396,13 @@ display:
       defaults:
         empty: false
         title: false
+        group_by: false
         fields: false
         sorts: false
         arguments: false
         filters: false
         filter_groups: false
+      group_by: true
       display_description: ''
       display_extenders: {  }
       block_hide_empty: true

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -1077,7 +1077,7 @@ display:
           type: entity_reference_label
           settings:
             link: true
-          group_column: target_id
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -1140,7 +1140,7 @@ display:
           type: entity_reference_label
           settings:
             link: true
-          group_column: target_id
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -1154,19 +1154,12 @@ display:
           id: field_news_item_tags
           table: node__field_news_item_tags
           field: field_news_item_tags
-          plugin_id: field
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: nid
           plugin_id: field
           label: ''
-          exclude: true
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -1198,7 +1191,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -1206,14 +1199,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: false
-          group_column: value
-          group_columns:
-            entity_id: entity_id
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings: {  }
+          group_column: entity_id
+          group_columns: {  }
           group_rows: true
           delta_limit: 0
           delta_offset: 0


### PR DESCRIPTION
# [UHF-8060](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8060)
There are duplicates in some of the "Of interest" listings at the bottom of news pages.

## What was done
* Added aggregation to the Of interest display of the Frontpage news view.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8060_Of-interest-duplicates`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Open a few news pages and check the "Of interest" block in the bottom. There should be no duplicates. One example where I could reproduce the bug is https://helfi-etusivu.docker.so/fi/uutiset/kevaan-ylioppilaskirjoitukset-alkoivat-parasta-menestysta-kaikille-kokelaille
* [x] Check that no other issues appeared in the list after the fix.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-8060]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ