### PR TITLE
UHF-7449: serve announcements from jsonapi

### DIFF
--- a/conf/cmi/core.entity_form_display.node.announcement.default.yml
+++ b/conf/cmi/core.entity_form_display.node.announcement.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.announcement.field_announcement_content_pages
     - field.field.node.announcement.field_announcement_link
     - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_publish_externally
     - node.type.announcement
   module:
     - hdbt_admin_editorial
@@ -72,6 +73,13 @@ content:
     settings:
       width: 100%
     third_party_settings: {  }
+  field_publish_externally:
+    type: boolean_checkbox
+    weight: 26
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 1
@@ -99,6 +107,11 @@ content:
     third_party_settings: {  }
   scheduler_settings:
     weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.announcement.default.yml
+++ b/conf/cmi/core.entity_view_display.node.announcement.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.announcement.field_announcement_content_pages
     - field.field.node.announcement.field_announcement_link
     - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_publish_externally
     - node.type.announcement
   module:
     - link
@@ -46,6 +47,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_publish_externally:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 4
     region: content
   links:
     settings: {  }

--- a/conf/cmi/core.entity_view_display.node.announcement.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.announcement.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.announcement.field_announcement_content_pages
     - field.field.node.announcement.field_announcement_link
     - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_publish_externally
     - node.type.announcement
   module:
     - text
@@ -38,6 +39,7 @@ hidden:
   field_announcement_content_pages: true
   field_announcement_link: true
   field_announcement_type: true
+  field_publish_externally: true
   langcode: true
   published_at: true
   search_api_excerpt: true

--- a/conf/cmi/field.field.node.announcement.field_publish_externally.yml
+++ b/conf/cmi/field.field.node.announcement.field_publish_externally.yml
@@ -9,7 +9,7 @@ id: node.announcement.field_publish_externally
 field_name: field_publish_externally
 entity_type: node
 bundle: announcement
-label: 'Publish externally'
+label: 'Julkaise ulkoisella sivustolla'
 description: ''
 required: false
 translatable: false

--- a/conf/cmi/field.field.node.announcement.field_publish_externally.yml
+++ b/conf/cmi/field.field.node.announcement.field_publish_externally.yml
@@ -1,0 +1,23 @@
+uuid: 82a48d96-00d4-4460-8a6f-6e8b42c32042
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publish_externally
+    - node.type.announcement
+id: node.announcement.field_publish_externally
+field_name: field_publish_externally
+entity_type: node
+bundle: announcement
+label: 'Publish externally'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Käytössä
+  off_label: 'Pois päältä'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_publish_externally.yml
+++ b/conf/cmi/field.storage.node.field_publish_externally.yml
@@ -1,0 +1,18 @@
+uuid: 98f1c4ed-c08f-4ffd-ad16-a1bea297761d
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_publish_externally
+field_name: field_publish_externally
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.node--announcement.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.node--announcement.yml
@@ -1,0 +1,227 @@
+uuid: d6ef928c-b4d9-462b-92c7-18fcd9c1acc2
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node--announcement
+disabled: false
+path: node/announcement
+resourceType: node--announcement
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: true
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: true
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: true
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: true
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  color_palette:
+    disabled: true
+    fieldName: color_palette
+    publicName: color_palette
+    enhancer:
+      id: ''
+  hide_sidebar_navigation:
+    disabled: true
+    fieldName: hide_sidebar_navigation
+    publicName: hide_sidebar_navigation
+    enhancer:
+      id: ''
+  toc_enabled:
+    disabled: true
+    fieldName: toc_enabled
+    publicName: toc_enabled
+    enhancer:
+      id: ''
+  toc_title:
+    disabled: true
+    fieldName: toc_title
+    publicName: toc_title
+    enhancer:
+      id: ''
+  metatag:
+    disabled: true
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: true
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  publish_on:
+    disabled: false
+    fieldName: publish_on
+    publicName: publish_on
+    enhancer:
+      id: ''
+  unpublish_on:
+    disabled: false
+    fieldName: unpublish_on
+    publicName: unpublish_on
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: true
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: true
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  published_at:
+    disabled: false
+    fieldName: published_at
+    publicName: published_at
+    enhancer:
+      id: ''
+  body:
+    disabled: false
+    fieldName: body
+    publicName: body
+    enhancer:
+      id: ''
+  field_announcement_all_pages:
+    disabled: true
+    fieldName: field_announcement_all_pages
+    publicName: field_announcement_all_pages
+    enhancer:
+      id: ''
+  field_announcement_content_pages:
+    disabled: true
+    fieldName: field_announcement_content_pages
+    publicName: field_announcement_content_pages
+    enhancer:
+      id: ''
+  field_announcement_link:
+    disabled: false
+    fieldName: field_announcement_link
+    publicName: field_announcement_link
+    enhancer:
+      id: ''
+  field_announcement_type:
+    disabled: false
+    fieldName: field_announcement_type
+    publicName: field_announcement_type
+    enhancer:
+      id: ''
+  field_publish_externally:
+    disabled: false
+    fieldName: field_publish_externally
+    publicName: field_publish_externally
+    enhancer:
+      id: ''

--- a/conf/cmi/language/en/field.field.node.announcement.field_publish_externally.yml
+++ b/conf/cmi/language/en/field.field.node.announcement.field_publish_externally.yml
@@ -1,0 +1,4 @@
+label: 'Publish on external website'
+settings:
+  on_label: 'On'
+  off_label: 'Off'


### PR DESCRIPTION
# [Global announcementsUHF-7449](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7749)
Allow globally sharing announcements on other instances via json api

## What was done
Added new resource to json-api
Added new field to announcement content type.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7449_announcement_sync`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Create a new announcement.
 - Set publish globally (julkaise ulkoisella sivustolla) as true
 - Save the announcement
- Go to `fi/jsonapi/node/announcement`
  - You should see the newly created announcement  

## Other PRs

### PLATFORM CONFIG PR GOES HERE.