### PR TITLE
Add global mobile menu get permission for auth and unauth users

### DIFF
--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - rest.resource.helfi_global_menu_collection
+    - rest.resource.helfi_global_mobile_menu
     - rest.resource.helfi_menu_link_collection
   module:
     - eu_cookie_compliance
@@ -24,6 +25,7 @@ permissions:
   - 'access openapi api docs'
   - 'display eu cookie compliance popup'
   - 'restful get helfi_global_menu_collection'
+  - 'restful get helfi_global_mobile_menu'
   - 'restful get helfi_menu_link_collection'
   - 'view global_menu'
   - 'view media'

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - rest.resource.helfi_global_menu_collection
+    - rest.resource.helfi_global_mobile_menu
     - rest.resource.helfi_menu_link_collection
   module:
     - draggableviews
@@ -29,6 +30,7 @@ permissions:
   - 'access toolbar'
   - 'display eu cookie compliance popup'
   - 'restful get helfi_global_menu_collection'
+  - 'restful get helfi_global_mobile_menu'
   - 'restful get helfi_menu_link_collection'
   - 'view global_menu'
   - 'view media'


### PR DESCRIPTION
Checkout this branch, make fresh

On both occasions you should see menu data as json:

- as unauthenticated user 
  - go to fi/api/v1/global-mobile-menu
- Log in as any other user
  - go to fi/api/v1/global-mobile-menu