### PR TITLE
UHF-8090 UI lang fix

### DIFF
--- a/conf/cmi/language.types.yml
+++ b/conf/cmi/language.types.yml
@@ -11,29 +11,29 @@ negotiation:
   language_content:
     enabled:
       language-url: -20
-      language-selected: -14
-      language-interface: 0
-    method_weights:
-      language-browser: -16
-      language-content-entity: -19
       language-interface: -15
       language-selected: -14
-      language-session: -18
+    method_weights:
       language-url: -20
+      language-content-entity: -19
+      language-session: -18
       language-user: -17
+      language-browser: -16
+      language-interface: -15
+      language-selected: -14
   language_url:
     enabled:
       language-url: 0
       language-url-fallback: 1
   language_interface:
     enabled:
-      language-user-admin: -10
-      language-url: -8
-      language-selected: 12
+      language-user-admin: -20
+      language-url: -18
+      language-selected: -15
     method_weights:
-      language-browser: -2
-      language-selected: 12
-      language-session: -6
-      language-url: -8
-      language-user: -4
-      language-user-admin: -10
+      language-user-admin: -20
+      language-url: -18
+      language-session: -17
+      language-user: -19
+      language-browser: -16
+      language-selected: -15

--- a/conf/cmi/language.types.yml
+++ b/conf/cmi/language.types.yml
@@ -28,12 +28,13 @@ negotiation:
   language_interface:
     enabled:
       language-user-admin: -20
+      language-user: -19
       language-url: -18
       language-selected: -15
     method_weights:
       language-user-admin: -20
+      language-user: -19
       language-url: -18
       language-session: -17
-      language-user: -19
       language-browser: -16
       language-selected: -15


### PR DESCRIPTION
# [UHF-8090](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8090)
Changing content language also changed the edit / view / translate / remove links above the content

## What was done
Enabled user language as ui language detection method and updated the priority over url language.

## How to install
* Include [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/609) to this one
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8090_ui_lang_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as admin
- Go to any content page with translated content
- Change the content translation from header language switcher
  - The action links above the content (View / Edit / Delete / Revisions / Translate) should not change based on content language.


## Related PRs

[HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/609)

[UHF-8090]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ