### PR TITLE
UHF-8141: Other language prefixes

### DIFF
--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -6,5 +6,16 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'en' => 'staging-frontpage',
   'fi' => 'staging-etusivu',
   'sv' => 'staging-huvudsida',
+  'ar' => 'staging-etusivu',
+  'de' => 'staging-etusivu',
+  'es' => 'staging-etusivu',
+  'et' => 'staging-etusivu',
+  'fa' => 'staging-etusivu',
+  'fr' => 'staging-etusivu',
+  'ru' => 'staging-etusivu',
+  'se' => 'staging-etusivu',
+  'so' => 'staging-etusivu',
+  'uk' => 'staging-etusivu',
+  'zh-hans' => 'staging-etusivu',
 ];
 

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -6,5 +6,16 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'en' => 'test-frontpage',
   'fi' => 'test-etusivu',
   'sv' => 'test-huvudsida',
+  'ar' => 'test-etusivu',
+  'de' => 'test-etusivu',
+  'es' => 'test-etusivu',
+  'et' => 'test-etusivu',
+  'fa' => 'test-etusivu',
+  'fr' => 'test-etusivu',
+  'ru' => 'test-etusivu',
+  'se' => 'test-etusivu',
+  'so' => 'test-etusivu',
+  'uk' => 'test-etusivu',
+  'zh-hans' => 'test-etusivu',
 ];
 


### PR DESCRIPTION
# [UHF-8141](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8141)
<!-- What problem does this solve? -->
Other languages need prefixes for the links to work on testing and staging environments.

## What was done
<!-- Describe what was done -->

* Added prefixes.

## How to install

* No installs needed

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
Basically only need to check the code and later test on testing and staging but if you want, you can copy the code changes to the `local.settings.php` and see if the prefixes work.

* [ ] Check the code changes.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8141]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ