### PR TITLE
UHF-X: Extend RTL support for templates

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--frontpage-news-of-interest.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--frontpage-news-of-interest.html.twig
@@ -1,7 +1,10 @@
 <div{{ attributes.addClass('block--news-of-interest') }}>
+{% set alternative_language = current_langcode not in primary_languages %}
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
+    <h2{{ title_attributes }} {{ alternative_language ? create_attribute(({ 'lang': 'en', 'dir': 'ltr' })) }}>
+      {{ label }}
+    </h2>
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--frontpage-news-of-interest.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--frontpage-news-of-interest.html.twig
@@ -1,5 +1,4 @@
 <div{{ attributes.addClass('block--news-of-interest') }}>
-{% set alternative_language = current_langcode not in primary_languages %}
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }} {{ alternative_language ? create_attribute(({ 'lang': 'en', 'dir': 'ltr' })) }}>

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--radioactivity-most-read-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--radioactivity-most-read-news.html.twig
@@ -1,5 +1,7 @@
 {% if label %}
-  <h2{{ title_attributes.addClass('sidebar_block_heading') }}>{{ label }}</h2>
+  {% set alternative_language = current_langcode not in primary_languages %}
+
+  <h2{{ title_attributes.addClass('sidebar_block_heading') }} {{ alternative_language ? create_attribute(({ 'lang': 'en', 'dir': 'ltr' })) }}>{{ label }}</h2>
 {% endif %}
 {% block content %}
   <div class="news-listing--sidebar">

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--radioactivity-most-read-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--radioactivity-most-read-news.html.twig
@@ -1,6 +1,4 @@
 {% if label %}
-  {% set alternative_language = current_langcode not in primary_languages %}
-
   <h2{{ title_attributes.addClass('sidebar_block_heading') }} {{ alternative_language ? create_attribute(({ 'lang': 'en', 'dir': 'ltr' })) }}>{{ label }}</h2>
 {% endif %}
 {% block content %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--news--latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--news--latest-news.html.twig
@@ -1,8 +1,16 @@
+{% set alternative_language = current_langcode not in primary_languages %}
 {% set link_attributes = {
   'class': [
     'link__read-more-news',
-  ],
+  ]
 } %}
+{% if alternative_language %}
+  {% set link_attributes = link_attributes|merge({
+      'dir': 'ltr',
+      'lang': 'en'
+    })
+  %}
+{% endif %}
 {% set link_title %}
   <span class="hds-button__label">{{ element['#title'] }}</span>
   {% include "@hdbt/misc/icon.twig" with {icon: 'arrow-right' } %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--news--latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--news--latest-news.html.twig
@@ -1,4 +1,3 @@
-{% set alternative_language = current_langcode not in primary_languages %}
 {% set link_attributes = {
   'class': [
     'link__read-more-news',

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--radioactivity--most-read-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--radioactivity--most-read-news.html.twig
@@ -1,8 +1,16 @@
+{% set alternative_language = current_langcode not in primary_languages %}
 {% set link_attributes = {
   'class': [
     'link__read-more-news',
-  ],
+  ]
 } %}
+{% if alternative_language %}
+  {% set link_attributes = link_attributes|merge({
+      'dir': 'ltr',
+      'lang': 'en'
+    })
+  %}
+{% endif %}
 {% set link_title %}
   <span class="hds-button__label">{{ element['#title'] }}</span>
   {% include "@hdbt/misc/icon.twig" with {icon: 'arrow-right' } %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--radioactivity--most-read-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--radioactivity--most-read-news.html.twig
@@ -1,4 +1,3 @@
-{% set alternative_language = current_langcode not in primary_languages %}
 {% set link_attributes = {
   'class': [
     'link__read-more-news',


### PR DESCRIPTION
# [UHF-8094](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8094)
Fix RTL issues in templates.

## What was done

Set `lang` and `dir` attributes for templates if language is outside of primary languages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-page-template-language-support`
  * `make fresh`
* Run `make drush-cr`

## How to test

Test with this branch: https://github.com/City-of-Helsinki/drupal-hdbt/pull/616 and follow instructions there

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [x] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/616


[UHF-8094]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ