### PR TITLE
UHF-8287: News title translations

### DIFF
--- a/conf/cmi/language/sv/views.view.frontpage_news.yml
+++ b/conf/cmi/language/sv/views.view.frontpage_news.yml
@@ -4,7 +4,7 @@ display:
       title: Toppnyheter
   of_interest:
     display_options:
-      title: 'Detta kan intressera dig'
+      title: 'Du kanske är intresserad av'
   latest_news:
     display_options:
       title: 'Senaste nyheter'

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -839,7 +839,7 @@ display:
     display_plugin: block
     position: 2
     display_options:
-      title: 'Of interest'
+      title: 'You might be interested in'
       fields:
         published_at:
           id: published_at


### PR DESCRIPTION
# [UHF-8287](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8287)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updates "Interested Of" title on View `frontpage_news` to more describing

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8287_News_title_translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure you have News Item created/translated for languages FI, SV and EN
* [ ] Open a News item for viewing and check translations for the title of Finnish version "Sinua voisi kiinnostaa" on EN and SV translations (see the issue description)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review



[UHF-8287]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ