### PR TITLE
UHF-8088: Language fallbacks for menu blocks.

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -43,6 +43,7 @@ module:
   hal: 0
   hdbt_admin_tools: 0
   health_check: 0
+  helfi_alt_lang_fallback: 0
   helfi_api_base: 0
   helfi_azure_fs: 0
   helfi_base_content: 0

--- a/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.info.yml
+++ b/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.info.yml
@@ -1,0 +1,10 @@
+name: helfi_alt_lang_fallback
+type: module
+description: Menu and block fallbacks for alternative languages
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:entity
+  - drupal:language
+  - drupal:content_translation
+  - drupal:helfi_navigation

--- a/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.module
+++ b/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.module
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Contains preprocess hooks for alternative language fallbacks.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Implements hook_block_alter().
+ */
+function helfi_alt_lang_fallback_block_alter(&$definitions) {
+  foreach ($definitions as $id => $definition) {
+    //dump($id);
+    // Check on your plugin Id here.
+    if ($id === 'external_menu_block_main_navigation') {
+      // Set your new class here.
+      //dump($definitions);
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_alt_lang_fallback_preprocess_region(&$variables): void {
+  /** @var \Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks $lang_fallbacks */
+  $lang_fallbacks = \Drupal::service('helfi_alt_lang_fallback');
+  if ($lang_fallbacks->shouldAttributesBeAddedToRegion($variables['region'])) {
+    $attributes = $lang_fallbacks->getLangAttributes();
+    $variables['attributes'] = array_replace($variables['attributes'], $attributes);
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_alt_lang_fallback_preprocess_block(&$variables): void {
+   /** @var \Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks $lang_fallbacks */
+  $lang_fallbacks = \Drupal::service('helfi_alt_lang_fallback');
+
+  if (empty($variables['plugin_id'])) {
+    return;
+  }
+
+  // Check if block is in the list to be altered.
+  if (!$lang_fallbacks->shouldAttributesBeAddedToBlock($variables['plugin_id'])) {
+    return;
+  }
+  // Check if block has fallback content. Otherwise add current lang attributes.
+  if ($lang_fallbacks->checkIfBlockHasFallbackContent($variables)) {
+    $attributes = $lang_fallbacks->getLangAttributes();
+  }
+  else {
+    $attributes = $lang_fallbacks->getCurrentLangAttributes();
+  }
+
+  // Add either fallback or current language attributes.
+  $variables['attributes'] = array_replace($variables['attributes'], $attributes);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_alt_lang_fallback_preprocess_menu(&$variables): void {
+  if (empty($variables['menu_name']) || empty($variables['items'])) {
+    return;
+  }
+
+  /** @var \Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks $lang_fallbacks */
+  $lang_fallbacks = \Drupal::service('helfi_alt_lang_fallback');
+  if (!$lang_fallbacks->shouldMenuTreeBeReplaced($variables['menu_name'], $variables['items'])) {
+    return;
+  }
+
+  $variables['items'] = $lang_fallbacks->replaceMenuTree($variables['menu_name']);
+}

--- a/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.module
+++ b/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.module
@@ -8,20 +8,6 @@
 declare(strict_types = 1);
 
 /**
- * Implements hook_block_alter().
- */
-function helfi_alt_lang_fallback_block_alter(&$definitions) {
-  foreach ($definitions as $id => $definition) {
-    //dump($id);
-    // Check on your plugin Id here.
-    if ($id === 'external_menu_block_main_navigation') {
-      // Set your new class here.
-      //dump($definitions);
-    }
-  }
-}
-
-/**
  * Implements hook_preprocess_HOOK().
  */
 function helfi_alt_lang_fallback_preprocess_region(&$variables): void {
@@ -37,7 +23,7 @@ function helfi_alt_lang_fallback_preprocess_region(&$variables): void {
  * Implements hook_preprocess_HOOK().
  */
 function helfi_alt_lang_fallback_preprocess_block(&$variables): void {
-   /** @var \Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks $lang_fallbacks */
+  /** @var \Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks $lang_fallbacks */
   $lang_fallbacks = \Drupal::service('helfi_alt_lang_fallback');
 
   if (empty($variables['plugin_id'])) {

--- a/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.services.yml
+++ b/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.services.yml
@@ -1,0 +1,4 @@
+services:
+  helfi_alt_lang_fallback:
+    class: Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks
+    arguments: ['@language_manager', '@entity_type.manager', '@menu.link_tree']

--- a/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.services.yml
+++ b/public/modules/custom/helfi_alt_lang_fallback/helfi_alt_lang_fallback.services.yml
@@ -1,4 +1,4 @@
 services:
   helfi_alt_lang_fallback:
     class: Drupal\helfi_alt_lang_fallback\AltLanguageFallbacks
-    arguments: ['@language_manager', '@entity_type.manager', '@menu.link_tree']
+    arguments: ['@language_manager', '@entity_type.manager', '@menu.link_tree', '@helfi_api_base.default_language_resolver']

--- a/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
+++ b/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
@@ -42,7 +42,7 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
   /**
    * Fallback language to default to.
    */
-  protected const FALLBACK_LANGUAGE = 'en';
+  public const FALLBACK_LANGUAGE = 'en';
 
   /**
    * Fallback regions to add language and direction attributes to.
@@ -89,7 +89,6 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
     'sv',
   ];
 
-
   /**
    * Constructs Ahjo Proxy service.
    *
@@ -122,12 +121,13 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
 
   /**
    * Check if current or specific language is considered not fully supported.
+   *
    * Does not account for language being actually in use.
    *
    * @param string|null $langcode
    *   Langcode to check. Defaults to current language.
    *
-   * @return boolean
+   * @return bool
    *   If language is considered alternative and not fully supported.
    */
   public function isAltLanguage(string $langcode = NULL): bool {
@@ -140,12 +140,13 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
 
   /**
    * Checks if region has fallback language content.
+   *
    * Currently only determined by region name.
    *
    * @param string $region_name
    *   Region name to check.
    *
-   * @return boolean
+   * @return bool
    *   Returns TRUE if we assume that region has fallback content.
    */
   public function shouldAttributesBeAddedToRegion(string $region_name): bool {
@@ -159,12 +160,13 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
 
   /**
    * Checks if block can have fallback language content.
+   *
    * Current language parameters are added if content is translated.
    *
    * @param string $plugin_id
    *   Block plugin ID to check.
    *
-   * @return boolean
+   * @return bool
    *   Returns TRUE if block can have fallback content.
    */
   public function shouldAttributesBeAddedToBlock(string $plugin_id): bool {
@@ -182,7 +184,7 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
    * @param array $variables
    *   Block preprocess variables.
    *
-   * @return boolean
+   * @return bool
    *   Returns TRUE if block has menus with fallback content.
    */
   public function checkIfBlockHasFallbackContent(array $variables): bool {
@@ -203,18 +205,15 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
     return $this->shouldMenuTreeBeReplaced($variables['content']['#menu_name'], $variables['content']['#items']);
   }
 
-
-
   /**
    * Checks if menu tree should be replaced by this service.
    *
    * @param string $menu_name
    *   Menu tree to check.
-   *
    * @param array $items
    *   Current menu items to check.
    *
-   * @return boolean
+   * @return bool
    *   Returns TRUE if menu should be handled by this module.
    */
   public function shouldMenuTreeBeReplaced(string $menu_name, array $items): bool {
@@ -268,6 +267,7 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
 
       $metadata = $link->getMetadata();
       $entity = $this->entityTypeManager->getStorage('menu_link_content')->load($metadata['entity_id']);
+      /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $entity */
       if ($entity->get('langcode')->value !== self::FALLBACK_LANGUAGE) {
         unset($tree[$key]);
       }
@@ -313,4 +313,5 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
       'dir' => $this->languageManager->getCurrentLanguage()->getDirection(),
     ];
   }
+
 }

--- a/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
+++ b/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
@@ -64,6 +64,9 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
    */
   protected array $fallbackBlocks = [
     'menu_block_current_language:header-top-navigation',
+    'menu_block_current_language:footer-top-navigation',
+    'menu_block_current_language:footer-top-navigation-2',
+    'menu_block_current_language:footer-bottom-navigation',
   ];
 
   /**
@@ -73,9 +76,9 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
    */
   protected array $fallbackMenus = [
     'header-top-navigation',
-    'footer-bottom-navigation',
     'footer-top-navigation',
     'footer-top-navigation-2',
+    'footer-bottom-navigation',
   ];
 
   /**

--- a/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
+++ b/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
@@ -15,7 +15,7 @@ use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
 /**
  * Handler for alternate language fallback service.
  *
- * @package Drupal\paatokset_ahjo_proxy
+ * @package Drupal\helfi_alt_lang_fallback
  */
 class AltLanguageFallbacks implements ContainerInjectionInterface {
 
@@ -85,7 +85,7 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
   ];
 
   /**
-   * Constructs Ahjo Proxy service.
+   * Constructs AltLanguageFallbacks service.
    *
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   Language manager.

--- a/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
+++ b/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
@@ -93,7 +93,7 @@ class AltLanguageFallbacks implements ContainerInjectionInterface {
    *   Entity type manager.
    * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree
    *   Menu tree builder.
-   * @param \Drupal\helfi_api_base\Language\DefaultLanguageResolver @default_language_resolver
+   * @param \Drupal\helfi_api_base\Language\DefaultLanguageResolver $default_language_resolver
    *   Default language resolver.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException

--- a/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
+++ b/public/modules/custom/helfi_alt_lang_fallback/src/AltLanguageFallbacks.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_alt_lang_fallback;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Menu\MenuLinkTreeInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Handler for alternate language fallback service.
+ *
+ * @package Drupal\paatokset_ahjo_proxy
+ */
+class AltLanguageFallbacks implements ContainerInjectionInterface {
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected LanguageManagerInterface $languageManager;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The menu tree factory.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
+   */
+  protected MenuLinkTreeInterface $menuTree;
+
+  /**
+   * Fallback language to default to.
+   */
+  protected const FALLBACK_LANGUAGE = 'en';
+
+  /**
+   * Fallback regions to add language and direction attributes to.
+   *
+   * @var array
+   */
+  protected array $fallbackRegions = [
+    'header_top',
+    'header_bottom',
+    'header_branding',
+    'footer_top',
+    'footer_bottom',
+  ];
+
+  /**
+   * Fallback blocks to add language and direction attributes to.
+   *
+   * @var array
+   */
+  protected array $fallbackBlocks = [
+    'menu_block_current_language:header-top-navigation',
+  ];
+
+  /**
+   * Fallback menus to regenerate menu trees for.
+   *
+   * @var array
+   */
+  protected array $fallbackMenus = [
+    'header-top-navigation',
+    'footer-bottom-navigation',
+    'footer-top-navigation',
+    'footer-top-navigation-2',
+  ];
+
+  /**
+   * List of fully supported languages. All others are handled by this service.
+   *
+   * @var array
+   */
+  protected array $standardLanguages = [
+    'fi',
+    'en',
+    'sv',
+  ];
+
+
+  /**
+   * Constructs Ahjo Proxy service.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   Language manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree
+   *   Menu tree builder.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function __construct(LanguageManagerInterface $language_manager, EntityTypeManagerInterface $entity_type_manager, MenuLinkTreeInterface $menu_tree) {
+    $this->languageManager = $language_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->menuTree = $menu_tree;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('language_manager'),
+      $container->get('entity_type.manager'),
+      $container->get('menu.link_tree'),
+    );
+  }
+
+  /**
+   * Check if current or specific language is considered not fully supported.
+   * Does not account for language being actually in use.
+   *
+   * @param string|null $langcode
+   *   Langcode to check. Defaults to current language.
+   *
+   * @return boolean
+   *   If language is considered alternative and not fully supported.
+   */
+  public function isAltLanguage(string $langcode = NULL): bool {
+    if (!$langcode) {
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
+    }
+
+    return !in_array($langcode, $this->standardLanguages);
+  }
+
+  /**
+   * Checks if region has fallback language content.
+   * Currently only determined by region name.
+   *
+   * @param string $region_name
+   *   Region name to check.
+   *
+   * @return boolean
+   *   Returns TRUE if we assume that region has fallback content.
+   */
+  public function shouldAttributesBeAddedToRegion(string $region_name): bool {
+    // Only act on alternative languages.
+    if (!$this->isAltLanguage()) {
+      return FALSE;
+    }
+
+    return in_array($region_name, $this->fallbackRegions);
+  }
+
+  /**
+   * Checks if block can have fallback language content.
+   * Current language parameters are added if content is translated.
+   *
+   * @param string $plugin_id
+   *   Block plugin ID to check.
+   *
+   * @return boolean
+   *   Returns TRUE if block can have fallback content.
+   */
+  public function shouldAttributesBeAddedToBlock(string $plugin_id): bool {
+    // Only act on alternative languages.
+    if (!$this->isAltLanguage()) {
+      return FALSE;
+    }
+
+    return in_array($plugin_id, $this->fallbackBlocks);
+  }
+
+  /**
+   * Checks if block has has fallback language content.
+   *
+   * @param array $variables
+   *   Block preprocess variables.
+   *
+   * @return boolean
+   *   Returns TRUE if block has menus with fallback content.
+   */
+  public function checkIfBlockHasFallbackContent(array $variables): bool {
+    // Only act on alternative languages.
+    if (!$this->isAltLanguage()) {
+      return FALSE;
+    }
+
+    // Check if menu has fallback content.
+    if (empty($variables['content'])) {
+      return FALSE;
+    }
+
+    if (empty($variables['content']['#menu_name']) || empty($variables['content']['#items'])) {
+      return FALSE;
+    }
+
+    return $this->shouldMenuTreeBeReplaced($variables['content']['#menu_name'], $variables['content']['#items']);
+  }
+
+
+
+  /**
+   * Checks if menu tree should be replaced by this service.
+   *
+   * @param string $menu_name
+   *   Menu tree to check.
+   *
+   * @param array $items
+   *   Current menu items to check.
+   *
+   * @return boolean
+   *   Returns TRUE if menu should be handled by this module.
+   */
+  public function shouldMenuTreeBeReplaced(string $menu_name, array $items): bool {
+    // Only act on alternative languages.
+    if (!$this->isAltLanguage()) {
+      return FALSE;
+    }
+
+    // Only act on specific menus.
+    if (!in_array($menu_name, $this->fallbackMenus)) {
+      return FALSE;
+    }
+
+    // Only act if menu has one <nolink> placeholder element.
+    if (empty($items) || count($items) > 1) {
+      return FALSE;
+    }
+
+    $item = array_shift($items);
+    if (!isset($item['url']) || !$item['url'] instanceof Url) {
+      return FALSE;
+    }
+
+    if ($item['url']->isRouted() && $item['url']->getRouteName() === '<nolink>') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Replace menu tree with default language links.
+   *
+   * @param string $menu_name
+   *   Name of the rerendered menu.
+   *
+   * @return array
+   *   Render array for rerendered menu tree.
+   */
+  public function replaceMenuTree(string $menu_name): array {
+    $parameters = $this->menuTree->getCurrentRouteMenuTreeParameters($menu_name);
+    $tree = $this->menuTree->load($menu_name, $parameters);
+
+    foreach ($tree as $key => $element) {
+      /** @var \Drupal\menu_link_content\Plugin\Menu\MenuLinkContent $link */
+      $link = $element->link;
+      // Only support menu_link_content elements for now.
+      if ($link->getProvider() !== 'menu_link_content') {
+        continue;
+      }
+
+      $metadata = $link->getMetadata();
+      $entity = $this->entityTypeManager->getStorage('menu_link_content')->load($metadata['entity_id']);
+      if ($entity->get('langcode')->value !== self::FALLBACK_LANGUAGE) {
+        unset($tree[$key]);
+      }
+    }
+
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+    ];
+
+    $tree = $this->menuTree->transform($tree, $manipulators);
+    $menu = $this->menuTree->build($tree);
+
+    if (!empty($menu['#items'])) {
+      return $menu['#items'];
+    }
+
+    return [];
+  }
+
+  /**
+   * Gets lang, dir and other attributes for fallback elements.
+   *
+   * @return array
+   *   Array with attributes.
+   */
+  public function getLangAttributes(): array {
+    return [
+      'lang' => self::FALLBACK_LANGUAGE,
+      'dir' => 'ltr',
+    ];
+  }
+
+  /**
+   * Gets lang, dir and other attributes for fallback elements.
+   *
+   * @return array
+   *   Array with attributes.
+   */
+  public function getCurrentLangAttributes(): array {
+    return [
+      'lang' => $this->languageManager->getCurrentLanguage()->getId(),
+      'dir' => $this->languageManager->getCurrentLanguage()->getDirection(),
+    ];
+  }
+}


### PR DESCRIPTION
# [UHF-8088](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088)

## What was done
New module for recreating certain menu trees based on a fallback languages on alternative languages. Also adds correct lang and dir attributes to specific blocks and regions.

**Support for internal menus:**
* Header top, footer top 1 & 2 and footer bottom menus support fallback languages
  * Fallback menu language is triggered by creating a single `<nolink>` placeholder element for the language inside the menu
  * The placeholder element is required to make the menu visible for the preprocess hook. It also makes it easier to create actual translations for these menus if necessary
* External menus (other languages menu and main navigation) are fetched in english by the helfi_navigation module if the current language isn't finnish, english or swedish 

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8088-fallback-languages`
  * `make fresh`
* Install related theme and module branches: `composer require drupal/hdbt:dev-UHF-8088-language-fallbacks  drupal/helfi_navigation:dev-UHF-8088-fallback-languages drupal/helfi_platform_config:dev-UHF-8088-fallback-languages drupal/helfi_api_base:dev-UHF-X_defualt_languages`
* Edit the following menus and add a placeholder `<nolink>` menu item on the languages you want to test. Test at least one RTL and one LTR language
  * https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/header-top-navigation
  * https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/footer-top-navigation
  * https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/footer-top-navigation-2
  * https://helfi-etusivu.docker.so/fi/admin/structure/menu/manage/footer-bottom-navigation
* For one language, create actual translated links instead of placeholders
* Add some English menu items to the other language links menu, since the test environment doesn't have any: https://helfi-etusivu.docker.so/en/admin/structure/menu/manage/header-language-links
* Add some English and alt language announcements: https://helfi-etusivu.docker.so/en/node/add/announcement
* Run `drush locale:check;drush locale:update;drush cr`

## How to test
* [x] Open the language versions you created placeholder links for
  * The header top and footer regions should show english content
  * The main navigation and megamenu should show english content (also on mobile)
  * The mobile / mega navigation open and close texts should be in english ("Menu" and "Close")
* [x] The translated menu items should appear on the language you created them on (but the main navigation should still be in english)
* [x] English announcement content should appear on alternative languages along with current language announcements
* [ ] Content should have the correct `dir` and `lang` attributes. If not on the element itself, then on one of its parent elements
* [x] If you navigate between different languages (including the standard ones), things should be cached correctly and nothing should break. Finnish and Swedish languages should not show any english menu content
  * The mobile / mega navigation open and close texts should be translated to finnish and swedish  
* [ ] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/351
* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/31
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/504
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/103


[UHF-8088]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ