### PR TITLE
UHF-8411: Label updates for paragraphs supported in other languages

### DIFF
--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.accordion.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.accordion.yml
@@ -1,2 +1,2 @@
-label: Haitari
+label: 'Haitari (tuettu muilla kielillä)'
 description: 'Haitari-elementtiä käytetään toissijaisen tiedon tallentamiseen kompaktissa muodossa. Sivuston käyttäjät näkevät tiedosta otsikon verran ensimmäisellä silmäyksellä ja voivat tarkastella sisältöä tarkemmin klikkaamalla otsikon auki.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.banner.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.banner.yml
@@ -1,2 +1,2 @@
-label: Banneri
+label: 'Banneri (tuettu muilla kielillä)'
 description: 'Banneri on leveä elementti, jonka avulla voit korostaa esimerkiksi tärkeitä linkkejä tai puhelinnumeroita. '

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.front_page_latest_news.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.front_page_latest_news.yml
@@ -1,2 +1,2 @@
-label: 'Uusimmat uutiset'
+label: 'Uusimmat uutiset (tuettu muilla kielillä)'
 description: 'Käytä ainoastaan etusivulla.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.front_page_top_news.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.front_page_top_news.yml
@@ -1,2 +1,2 @@
-label: Pääuutiset
+label: 'Pääuutiset (tuettu muilla kielillä)'
 description: 'Käytä ainoastaan etusivulla.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.image.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Kuva kuvatekstillä'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.list_of_links.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.list_of_links.yml
@@ -1,2 +1,2 @@
-label: Linkkilista
+label: 'Linkkilista (tuettu muilla kielillä)'
 description: 'Lista sisäisiä tai ulkoisia linkkejä. Valittavissa erilaisia listatyylejä.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.popular_services.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.popular_services.yml
@@ -1,2 +1,2 @@
-label: 'Suositut palvelut '
+label: 'Suositut palvelut  (tuettu muilla kielillä)'
 description: 'Esittele suosittuja palveluita.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.remote_video.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.remote_video.yml
@@ -1,2 +1,2 @@
-label: 'Video ulkoisesta palvelusta'
+label: 'Video ulkoisesta palvelusta (tuettu muilla kielillä)'
 description: 'Tällä lohkolla voit upottaa videon ulkoisesta palvelusta. Tukee tällä hetkellä vain YouTubea.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.sidebar_text.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.sidebar_text.yml
@@ -1,1 +1,1 @@
-label: 'Sivupalkin teksti'
+label: 'Sivupalkin teksti (tuettu muilla kielillä)'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.text.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.text.yml
@@ -1,1 +1,1 @@
-label: Teksti
+label: 'Teksti (tuettu muilla kielillä)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.accordion.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.accordion.yml
@@ -1,0 +1,1 @@
+label: 'Accordion (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.banner.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.banner.yml
@@ -1,0 +1,1 @@
+label: 'Banner (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.front_page_latest_news.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.front_page_latest_news.yml
@@ -1,2 +1,2 @@
-label: 'Senaste nytt'
+label: 'Senaste nytt (stöds på andra språk)'
 description: 'Använd endast på förstasidan.'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.front_page_top_news.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.front_page_top_news.yml
@@ -1,2 +1,2 @@
-label: Toppnyheter
+label: 'Toppnyheter (stöds på andra språk)'
 description: 'Använd endast på förstasidan.'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.image.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.list_of_links.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.list_of_links.yml
@@ -1,0 +1,1 @@
+label: 'List of links (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.popular_services.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.popular_services.yml
@@ -1,0 +1,1 @@
+label: 'Popular services (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.remote_video.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.remote_video.yml
@@ -1,1 +1,1 @@
-label: 'Extern video'
+label: 'Extern video (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.sidebar_text.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.sidebar_text.yml
@@ -1,0 +1,1 @@
+label: 'Sidebar text (stöds på andra språk)'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.text.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.text.yml
@@ -1,1 +1,1 @@
-label: Text
+label: 'Text (stöds på andra språk)'

--- a/conf/cmi/paragraphs.paragraphs_type.accordion.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.accordion.yml
@@ -10,7 +10,7 @@ third_party_settings:
 _core:
   default_config_hash: d9QHZSNb78KFueRqSVFC7_maG4KBNgjsPmLJIb2TN10
 id: accordion
-label: Accordion
+label: 'Accordion (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Accordion paragraph is used to store information that is perhaps not so relevant to all website users in a compact element that collapses the additional information behind a title.'

--- a/conf/cmi/paragraphs.paragraphs_type.banner.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.banner.yml
@@ -10,7 +10,7 @@ third_party_settings:
 _core:
   default_config_hash: 5psLSGdGhJB25T2TTd44M1_ObQNb2ii3jKv5ebjaDT4
 id: banner
-label: Banner
+label: 'Banner (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Banner is a simple full-width element that you can use to promote for example important links or phone numbers. '

--- a/conf/cmi/paragraphs.paragraphs_type.front_page_latest_news.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.front_page_latest_news.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: front_page_latest_news
-label: 'Latest news'
+label: 'Latest news (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Use only on front page.'

--- a/conf/cmi/paragraphs.paragraphs_type.front_page_top_news.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.front_page_top_news.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: front_page_top_news
-label: 'Top news'
+label: 'Top news (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Use only on front page.'

--- a/conf/cmi/paragraphs.paragraphs_type.image.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.image.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 _core:
   default_config_hash: M-cucF_MywQRWs1GedbjUzT6HAIH-QUhLICxcZgEPFg
 id: image
-label: Image
+label: 'Image (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Image with a caption'

--- a/conf/cmi/paragraphs.paragraphs_type.list_of_links.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.list_of_links.yml
@@ -10,7 +10,7 @@ third_party_settings:
 _core:
   default_config_hash: rlTppk1e9-X4A1utAhQ2iP-NbeR3H15DOMrpb--XdVY
 id: list_of_links
-label: 'List of links'
+label: 'List of links (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'List of internal or external links. Different designs available.'

--- a/conf/cmi/paragraphs.paragraphs_type.popular_services.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.popular_services.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 _core:
   default_config_hash: Gyo3CpUZxBSdsdG7AWD78G94KsaFV-oPTYXF1ahduYw
 id: popular_services
-label: 'Popular services'
+label: 'Popular services (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Showcase popular services'

--- a/conf/cmi/paragraphs.paragraphs_type.remote_video.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.remote_video.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 _core:
   default_config_hash: WTAPpeTZCHB5rS01AM02G5tEkQ7LMFLOfPD-MW0Hir4
 id: remote_video
-label: 'Remote video'
+label: 'Remote video (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: 'Remote video paragraph that lets you add any video from video providers. Currently only YouTube.'

--- a/conf/cmi/paragraphs.paragraphs_type.sidebar_text.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.sidebar_text.yml
@@ -10,7 +10,7 @@ third_party_settings:
 _core:
   default_config_hash: eTaYwUTssthgegDKXXVauF-8HIAezuwWcXeKrTbt1aI
 id: sidebar_text
-label: 'Sidebar text'
+label: 'Sidebar text (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: ''

--- a/conf/cmi/paragraphs.paragraphs_type.text.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.text.yml
@@ -10,7 +10,7 @@ third_party_settings:
 _core:
   default_config_hash: quCqNy8X3E6ITit4b7BJnq9E6Ai6Tx3xYpBz1pByy0E
 id: text
-label: Text
+label: 'Text (supported in other languages)'
 icon_uuid: null
 icon_default: null
 description: ''


### PR DESCRIPTION
# [UHF-8411](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8411)
<!-- What problem does this solve? -->
Editors should know which paragraphs are supported in other languages.

## What was done
<!-- Describe what was done -->

* Added "supported in other languages" text to the paragraph labels.

### List of paragraphs that are supported in other languages

- Text
- Image
- Banner
- Remote video
- Top news
- Latest news
- List of links
- Popular services
- Accordion
- Sidebar text

## How to install

* Make sure your etusivu instance is up and running on correct branch.
  * `git checkout UHF-8411_Update-paragraph-labels`
  * `make fresh`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go add or edit a page and check the component list. The components that are supported in other languages should have (supported in other languages) in end of their names.
* [ ] Check that the added text is translated to all main languages (Finnish, Swedish and English)

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
