### PR TITLE
UHF-8382: Set preferred admin language on login if not set.

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.info.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.info.yml
@@ -7,5 +7,6 @@ dependencies:
   - drupal:rest
   - draggableviews:draggableviews
   - helfi_api_base:helfi_api_base
+  - helfi_tunnistamo:helfi_tunnistamo
 'interface translation project': helfi_etusivu
 'interface translation server pattern': modules/custom/helfi_etusivu/translations/%language.po

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -11,8 +11,11 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
+use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\MediaInterface;
+use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
+use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
@@ -157,7 +160,7 @@ function helfi_etusivu_theme_registry_alter(&$theme_registry) : void {
 /**
  * Implements hook_preprocess_HOOK().
  */
-function helfi_etusivu_preprocess_toolbar(&$variables): void {
+function helfi_etusivu_preprocess_toolbar(&$variables) : void {
   $variables['#attached']['library'][] = 'helfi_etusivu/menu-styles';
 }
 
@@ -169,5 +172,22 @@ function helfi_etusivu_block_alter(&$definitions) {
     if ($id === 'local_tasks_block') {
       $definitions[$id]['class'] = 'Drupal\helfi_etusivu\Plugin\Block\EtusivuLocalTasksBlock';
     }
+  }
+}
+
+/**
+ * Implements hook_openid_connect_post_authorize().
+ */
+function helfi_etusivu_openid_connect_post_authorize(UserInterface $account, array $context) : void {
+  $plugin = OpenIDConnectClientEntity::load($context['plugin_id'])?->getPlugin();
+
+  if (!$plugin instanceof Tunnistamo) {
+    return;
+  }
+
+  // If preferred admin langcode not set, set a default value.
+  if (!$account->getPreferredAdminLangcode(FALSE)) {
+    $account->set('preferred_admin_langcode', 'fi');
+    $account->save();
   }
 }


### PR DESCRIPTION
# [UHF-8382](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8382)
Admin user interface acts funny if preferred admin langcode is not set and you are editing translations.

## What was done
Added functionality which updates user's preferred admin langcode to FI on tunnistamo-login if user's preferred admin langcode is UND.

## How to install

Cannot be tested on local environment AFAIK.


[UHF-8382]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ