### PR TITLE
UHF-8468 Enabled Askem (React & Share) on news item pages on front page instance

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_eucookiecomplianceblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_eucookiecomplianceblock.yml
@@ -12,7 +12,7 @@ _core:
 id: hdbt_subtheme_eucookiecomplianceblock
 theme: hdbt_subtheme
 region: after_content
-weight: -9
+weight: -13
 provider: null
 plugin: eu_cookie_compliance_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - hdbt_admin_tools
+    - helfi_platform_config
     - node
   theme:
     - hdbt_subtheme

--- a/conf/cmi/block.block.hdbt_subtheme_lowercontentblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_lowercontentblock.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - hdbt_admin_tools
+    - helfi_platform_config
   theme:
     - hdbt_subtheme
 _core:
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_lowercontentblock
 theme: hdbt_subtheme
 region: after_content
-weight: -10
+weight: -14
 provider: null
 plugin: lower_content_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - helfi_platform_config
+    - language
     - node
   theme:
     - hdbt_subtheme
@@ -30,3 +31,12 @@ visibility:
       announcement: announcement
       landing_page: landing_page
       page: page
+  language:
+    id: language
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_interface'
+    langcodes:
+      fi: fi
+      sv: sv
+      en: en

--- a/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
@@ -1,6 +1,6 @@
 uuid: c6c05b70-2940-4dc2-bdbc-417d777274db
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_platform_config
@@ -12,7 +12,7 @@ _core:
 id: hdbt_subtheme_reactandshare
 theme: hdbt_subtheme
 region: after_content
-weight: -8
+weight: -11
 provider: null
 plugin: react_and_share
 settings:
@@ -28,4 +28,5 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       announcement: announcement
-      news_item: news_item
+      landing_page: landing_page
+      page: page

--- a/conf/cmi/block.block.hdbt_subtheme_sidebarcontentblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_sidebarcontentblock.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - hdbt_admin_tools
+    - helfi_platform_config
   theme:
     - hdbt_subtheme
 _core:

--- a/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hdbt_subtheme_views_block__frontpage_news_of_interest
 theme: hdbt_subtheme
 region: after_content
-weight: 0
+weight: -12
 provider: null
 plugin: 'views_block:frontpage_news-of_interest'
 settings:


### PR DESCRIPTION
# [UHF-8468](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8468)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Enabled Askem (React & Share) block on news item pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8468_enable_react_and_share`
  * `make fresh`
* Run `make drush-cr`
* Add React and Share API keys to your local.settings.php file (ask Tero if you don't know what the keys are).

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any news item page such as https://helfi-etusivu.docker.so/fi/uutiset/mannerheimintien-peruskorjaus-sulkee-baanan-alikulun-15-toukokuuta and accept all cookies. You should now see React & Share block on the bottom of the page.
* [ ] Make sure the block is NOT visible anywhere else in the front page instance such as landing pages or standard pages.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8468]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ