### PR TITLE
Add fallback filter for 'tags' parameter

### DIFF
--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -1164,6 +1164,59 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        field_news_item_tags_target_id_2:
+          id: field_news_item_tags_target_id_2
+          table: node__field_news_item_tags
+          field: field_news_item_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_news_item_tags_target_id_2_op
+            label: 'News tags fallback (field_news_item_tags)'
+            description: ''
+            use_operator: false
+            operator: field_news_item_tags_target_id_2_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: tags
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              menu_api: '0'
+              news_producer: '0'
+              debug_api: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: news_tags
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
# [UHF-8605](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8605)
Add fallback compatibility for old news tags parameter

## What was done
Added new filter to RSS feed to replace old tags parameter

## How to install

Make sure your elastic is up and running:
* `make up`
* `make ps` and check which port your elastic is running in
* Add this to your .env in this manner: `ELASTIC_PROXY_URL=http://localhost:{port your elastic is runnning in}`
* `make up` again

Make sure your instance is up and running on correct branch.
* `git fetch`
* `git checkout origin/UHF-8605-backwards-compatibility-for-rss`
* `make fresh`
* Run `make drush-cr`

## How to test

We need to make sure that when filtering the RSS feed, `tags` and `topic` parameters are interchangeable. You can test this by making some searches in https://helfi-etusivu.docker.so/fi/uutiset:
* Make some selections in the topic ("aiheet") filter
* Copy the link from the "Subscribe RSS" button
* View the link in postman (or similar) or view the source in your browser
* Make note of the results you get
* Change the `topics` parameter to `tags`. You should get the same list of results

Also check that the config change makes sense

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)



[UHF-8605]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ