### PR TITLE
UHF-8390 D10 deprecation

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -110,6 +110,7 @@ function helfi_etusivu_cron() : void {
     ->condition('promote', 1)
     ->condition('created', strtotime('-1 month'), '<')
     ->range(0, 50)
+    ->accessCheck(FALSE)
     ->execute();
 
   $promoted_nodes = \Drupal::entityTypeManager()

--- a/public/modules/custom/helfi_news_archive/helfi_news_archive.info.yml
+++ b/public/modules/custom/helfi_news_archive/helfi_news_archive.info.yml
@@ -1,6 +1,6 @@
 name: HELfi News Archive
 description: Module for rendering news archive application
 type: module
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: ^9 || ^10
 'interface translation project': helfi_news_archive
 'interface translation server pattern': modules/custom/helfi_news_archive/translations/%language.po

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
@@ -3,7 +3,7 @@ description: Subtheme for Helsinki Drupal instances.
 type: theme
 base theme: hdbt
 tags: sub-theme
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 screenshot: hdbt_subtheme.png
 'interface translation project': hdbt_subtheme
 'interface translation server pattern': themes/custom/hdbt_subtheme/translations/%language.po


### PR DESCRIPTION
Updated core version requirements
Added entity query access check

How to test:
Setup the site normally
Go to front page and admin side status page
The site should work

You can also test the D10 readiness status by following these steps:
run `composer require drupal/upgrade_status` and `drush en -y upgrade_status`

Running these commands below should only yield prophesy/prophesize errors:
for all custom modules run `drush upgrade_status:analyze helfi_custom_module_name_here`
run `drush upgrade_status:analyze hdbt_subtheme`