### PR TITLE
UHF-8679: News item alias pattern for other languages

### DIFF
--- a/conf/cmi/pathauto.pattern.news_item_other_languages.yml
+++ b/conf/cmi/pathauto.pattern.news_item_other_languages.yml
@@ -1,0 +1,43 @@
+uuid: 49345a03-e90c-4cc3-9416-c42d55b08908
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: news_item_other_languages
+label: 'News item | other languages'
+type: 'canonical_entities:node'
+pattern: 'news/[node:short-title]'
+selection_criteria:
+  846ebfb3-db99-49ae-995f-bd9c76421de7:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 846ebfb3-db99-49ae-995f-bd9c76421de7
+    context_mapping:
+      node: node
+    bundles:
+      news_item: news_item
+  e9eeca0d-99dd-4382-b774-038884ec062f:
+    id: language
+    negate: false
+    uuid: e9eeca0d-99dd-4382-b774-038884ec062f
+    context_mapping:
+      language: 'node:langcode:language'
+    langcodes:
+      de: de
+      fr: fr
+      ru: ru
+      uk: uk
+      ar: ar
+      et: et
+      fa: fa
+      es: es
+      so: so
+      se: se
+      zh-hans: zh-hans
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language


### PR DESCRIPTION
# [UHF-8679](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8679)
<!-- What problem does this solve? -->
News items on other languages are getting /node/xxxx type of URLs because they don't have path alias set.

## What was done
<!-- Describe what was done -->

* Added alias pattern for news items on other languguages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8679_other-languages-alias-pattern`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Create new page in one of the other languages (not fi, sv or en) and check that it gets path alias automatically and it follows news/[node:short-title].

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-8679]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ