### PR TITLE
UHF-6102: Enable latest news paragraph for front page instance standard page lower content region

### DIFF
--- a/conf/cmi/field.field.node.page.field_lower_content.yml
+++ b/conf/cmi/field.field.node.page.field_lower_content.yml
@@ -14,6 +14,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.front_page_latest_news
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
@@ -53,6 +54,7 @@ settings:
       phasing: phasing
       remote_video: remote_video
       map: map
+      front_page_latest_news: front_page_latest_news
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -80,6 +82,9 @@ settings:
         weight: 0
         enabled: true
       from_library:
+        weight: 0
+        enabled: true
+      front_page_latest_news:
         weight: 0
         enabled: true
       image:

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -210,7 +210,9 @@ function helfi_etusivu_update_9007() : void {
   }
 }
 
-
+/**
+ * UHF-6102: Add latest news paragraph to lower content area on basic page.
+ */
 function helfi_etusivu_update_9008(): void {
   helfi_platform_config_update_paragraph_target_types();
 }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -209,3 +209,8 @@ function helfi_etusivu_update_9007() : void {
       ->save();
   }
 }
+
+
+function helfi_etusivu_update_9008(): void {
+  helfi_platform_config_update_paragraph_target_types();
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -129,19 +129,32 @@ function helfi_etusivu_cron() : void {
  * Implements hook_helfi_paragraph_types().
  */
 function helfi_etusivu_helfi_paragraph_types() : array {
-  $types = [
-    'field_content' => [
-      'front_page_latest_news',
-      'front_page_top_news',
-      'current',
-      'event_list',
+  $entities = [
+    'node' => [
+      'landing_page' => [
+        'field_content' => [
+          'front_page_latest_news',
+          'front_page_top_news',
+          'current',
+          'event_list',
+        ],
+      ],
+      'page' => [
+        'field_lower_content' => [
+          'front_page_latest_news',
+        ],
+      ],
     ],
   ];
 
   $enabled = [];
-  foreach ($types as $field => $paragraphTypes) {
-    foreach ($paragraphTypes as $paragraphType) {
-      $enabled[] = new ParagraphTypeCollection('node', 'landing_page', $field, $paragraphType);
+  foreach ($entities as $entityTypeId => $bundles) {
+    foreach ($bundles as $bundle => $fields) {
+      foreach ($fields as $field => $paragraphTypes) {
+        foreach ($paragraphTypes as $paragraphType) {
+          $enabled[] = new ParagraphTypeCollection($entityTypeId, $bundle, $field, $paragraphType);
+        }
+      }
     }
   }
   return $enabled;


### PR DESCRIPTION
# [UHF-6102](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6102)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added latest news paragraph to standard page lower content region.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-6102_latest_news_for_standard_page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that you are able to add latest news paragraph to standard page lower content region now.
* [x] Make sure it looks good on the standard page as well.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-6102]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ