### PR TITLE
UHF-X: Add accidentally removed hero design with search back

### DIFF
--- a/conf/cmi/field.storage.paragraph.field_hero_design.yml
+++ b/conf/cmi/field.storage.paragraph.field_hero_design.yml
@@ -28,6 +28,9 @@ settings:
     -
       value: diagonal
       label: Diagonal
+    -
+      value: with-search
+      label: 'With search'
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
# UHF-X: Add accidentally removed hero design with search back
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Accidentally removed configuration was added back for hero design "With search"

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_add_with_search_hero_design_back`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure drush cim goes through and you can still add hero design: with search.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
