### PR TITLE
UHF-8701: removed broken sitemap index links

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://www.hel.fi/fi/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://www.hel.fi/fi/asuminen/sitemap.xml</loc>
   </sitemap>
   <sitemap>
@@ -26,8 +23,5 @@
   </sitemap>
   <sitemap>
     <loc>https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.hel.fi/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
# [UHF-8701](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8701)

Removed broken sitemap link and circular reference to sitemap index.


[UHF-8701]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ