### PR TITLE
UHF-8573: Enable filtering by all languages in content list.

### DIFF
--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -487,6 +487,17 @@ display:
             fi: fi
             sv: sv
             en: en
+            de: de
+            fr: fr
+            ru: ru
+            uk: uk
+            ar: ar
+            et: et
+            fa: fa
+            es: es
+            so: so
+            se: se
+            zh-hans: zh-hans
           group: 1
           exposed: true
           expose:
@@ -504,8 +515,13 @@ display:
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
-              admin: '0'
+              read_only: '0'
               content_producer: '0'
+              editor: '0'
+              admin: '0'
+              menu_api: '0'
+              news_producer: '0'
+              debug_api: '0'
             reduce: true
           is_grouped: false
           group_info:


### PR DESCRIPTION
# [UHF-8573](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8573)

## What was done
Adds all enabled languages to exposed filter in content view.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8573-add-languages-filters`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [ ] Go to https://helfi-etusivu.docker.so/fi/admin/content and check that the "Language" filter has all enabled languages, not just finnish, swedish and english.
* [ ] Check that the filter works
* [ ] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review

[UHF-8573]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ