### PR TITLE
UHF-1781: Change hero field_hero_design to use function for allowed values

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -185,3 +185,11 @@ function helfi_etusivu_block_alter(&$definitions) {
     }
   }
 }
+
+/**
+ * Implements hook_helfi_hero_design_alter().
+ */
+function helfi_etusivu_helfi_hero_design_alter(array &$designs): void {
+  $designs['with-search'] = t('With search');
+  $designs['test'] = t('test');
+}


### PR DESCRIPTION
# [UHF-1781](https://helsinkisolutionoffice.atlassian.net/browse/UHF-1781)
<!-- What problem does this solve? -->
Updates were not passing on front page instance because the allowed values list for hero is different for front page and other instances.

## What was done
<!-- Describe what was done -->

* Changed the hero paragraph field_hero_design to use function to define allowed values instead of the fixed list in the configuration.

## How to install

* Make sure your instance is up and running on correct branch. First try with some other instance than front page, then check the front page instance PR.
  * `git checkout UHF-1781_hero_designs_allowed_values_change`
  * `make fresh`
* Run `make drush-cr drush-updb`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that database updates pass correctly.
* [ ] Check that hero-blocks still have same designs available and work normally (without-image-left, with-image-right, with-image-left, with-image-bottom and diagonal)
* [ ] If you run `make drush-cex` the `field.storage.paragraph.field_hero_design.yml` file should change and `allowed_values_function` should have `helfi_paragraphs_hero_design_allowed_values` set.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
