### PR TITLE
UHF-8707: Fixed other languages bugs in latest news component

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-latest-news.html.twig
@@ -3,6 +3,7 @@
     {
       component_classes: [ 'component--latest-news' ],
       component_title: 'Latest news'|t({}, {'context': 'Front page latest news paragraph title'}),
+      use_component_title_lang_fallback: alternative_language ?? false,
       component_content_class: 'latest-news',
     }
   %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--frontpage-news--latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--frontpage-news--latest-news.html.twig
@@ -9,4 +9,12 @@
   {% include "@hdbt/misc/icon.twig" with {icon: 'arrow-right' } %}
 {% endset %}
 
+{% if alternative_language %}
+  {% set link_attributes = link_attributes|merge({
+    'dir': lang_attributes.fallback_dir,
+    'lang': lang_attributes.fallback_lang
+    })
+  %}
+{% endif %}
+
 {{ link(link_title, element['#url'], link_attributes) }}


### PR DESCRIPTION
# [UHF-8707](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8707)
<!-- What problem does this solve? -->
The "See all news" button in latest news component didn't have language attribute fallback on other languages.

## What was done
<!-- Describe what was done -->

* Added the missing fallback attributes.

## How to install

* Make sure your etusivu instance is up and running on correct branch.
  * `git checkout UHF-8707_other-languages-bugs`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Open https://helfi-etusivu.docker.so/uk/hromada-helsinki-pidtrymuye-bizhentsiv-z-ukrayiny-ta-ukrayintsiv-yaki-zalyshylysya-v-finlyandiyi#latest-news and check that the "See all news" button has the lang="en" dir="ltr" attributes.
* [x] The other change (in the `paragraph--front-page-latest-news.html.twig`) is a helper for the other PR.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/750)


[UHF-8707]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ