### PR TITLE
UHF-9080: added contextual filter for news list

### DIFF
--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -1301,6 +1301,44 @@ display:
             field_identifier: ''
           exposed: false
           granularity: minute
+      arguments:
+        field_news_item_tags_target_id:
+          id: field_news_item_tags_target_id
+          table: node__field_news_item_tags
+          field: field_news_item_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: topic
+            fallback: all
+            multiple: and
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
           id: status
@@ -1376,6 +1414,7 @@ display:
           1: AND
       defaults:
         sorts: false
+        arguments: false
         filters: false
         filter_groups: false
       display_extenders: {  }
@@ -1385,6 +1424,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
       tags:


### PR DESCRIPTION
# [UHF-9080](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9080)
React fallback view should return correct values

## What was done
Added contextual filter to react fallback view

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9080`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Go to fi/uutiset
- Use the react search to generate query parameters for the fallback search
  - add any topic filter and apply. make sure the topic has news in it.
- Disable javascript to see the fallback list with query parameters
  - At this point, the result should show similar list of news filtered by topic-filter.
- Try adding page-filter manyally by adding `&page=2` to the url, the result should change on page load. The result count or order may vary if the react does some sorting logic.


* [x] Check that this feature works
* [x] Check that code follows our standards

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/335


[UHF-9080]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ