### PR TITLE
UHF-8986: disallow search query parameters

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -45,6 +45,15 @@ Disallow: */user/register
 Disallow: */user/password
 Disallow: */user/login
 Disallow: */user/logout
+# Etusivu news-search page query parameters, topic and page allowed
+Disallow: /*?*groups
+Disallow: /*?*neighbourhoods
+# Rekry job-search page query parameters, task_areas and page are allowed.
+Disallow: /*?*employment=*
+Disallow: /*?*keyword=*
+Disallow: /*?*language=*
+Disallow: /*?*continuous=*
+Disallow: /*?*internship=*
 
 # Old robots
 #
@@ -162,7 +171,3 @@ Disallow: /wps/portal/HelsinkiV2/
 
 User-agent: WEX/IBMtest
 Allow: /static/mirror-v2/
-
-# News search query parameters, topic and page allowed
-Disallowed: /*?*groups
-Disallowed: /*?*neighbourhoods

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -162,3 +162,7 @@ Disallow: /wps/portal/HelsinkiV2/
 
 User-agent: WEX/IBMtest
 Allow: /static/mirror-v2/
+
+# News search query parameters, topic and page allowed
+Disallowed: /*?*groups
+Disallowed: /*?*neighbourhoods


### PR DESCRIPTION
# [UHF-8986](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8986)
<!-- What problem does this solve? -->

Less indexed urls for news search page.
Also contains Rekry's job search query parameters

## What was done

Added query parameters to robots.txt as disallowed

## How to install

Cannot be tested on local as far as I know

## How to test

Cannot be tested on local as far as I know

## Other PRs
[rekry](https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/358) & [paatokset](https://github.com/City-of-Helsinki/helsinki-paatokset/pull/341)

[UHF-8986]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ