### PR TITLE
UHF-X Add missing translation to latest news block title

### DIFF
--- a/conf/cmi/language/fi/core.entity_form_display.paragraph.phasing.default.yml
+++ b/conf/cmi/language/fi/core.entity_form_display.paragraph.phasing.default.yml
@@ -1,0 +1,5 @@
+content:
+  field_phasing_item:
+    settings:
+      title: Lohko
+      title_plural: Lohkot

--- a/conf/cmi/language/fi/core.entity_view_mode.media.image.yml
+++ b/conf/cmi/language/fi/core.entity_view_mode.media.image.yml
@@ -1,1 +1,1 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'

--- a/conf/cmi/language/fi/field.field.media.image.field_media_image.yml
+++ b/conf/cmi/language/fi/field.field.media.image.field_media_image.yml
@@ -1,1 +1,1 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'

--- a/conf/cmi/language/fi/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Vaaka- ja pystykuvat rajataan neliöiksi. Rajatun kuvan keskipisteen voi valita kuvan latauksen yhteydessä. '

--- a/conf/cmi/language/fi/field.field.paragraph.hero.field_hero_image.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.hero.field_hero_image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Kuva jota käytetään kuvituskuvana tai taustakuvana lohkossa riippuen siitä minkä tyylin olet lohkolle valinnut.'

--- a/conf/cmi/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Kuva jota käytetään kuvituskuvana tai taustakuvana lohkossa riippuen siitä minkä tyylin olet lohkolle valinnut.'

--- a/conf/cmi/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Kuva jota käytetään linkin yhteydessä.'

--- a/conf/cmi/language/fi/field.field.paragraph.phasing.field_show_phase_numbers.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.phasing.field_show_phase_numbers.yml
@@ -1,1 +1,4 @@
 label: 'Näytä vaiheiden numerot'
+settings:
+  on_label: Kyllä
+  off_label: Ei

--- a/conf/cmi/language/fi/language.entity.de.yml
+++ b/conf/cmi/language/fi/language.entity.de.yml
@@ -1,0 +1,1 @@
+label: Saksa

--- a/conf/cmi/language/fi/language.entity.es.yml
+++ b/conf/cmi/language/fi/language.entity.es.yml
@@ -1,0 +1,1 @@
+label: Espanja

--- a/conf/cmi/language/fi/language.entity.fr.yml
+++ b/conf/cmi/language/fi/language.entity.fr.yml
@@ -1,0 +1,1 @@
+label: Ranska

--- a/conf/cmi/language/fi/media.type.image.yml
+++ b/conf/cmi/language/fi/media.type.image.yml
@@ -1,2 +1,2 @@
-label: Kuva
+label: 'Kuva (tuettu muilla kielillä)'
 description: 'Mediatyyppi kuville.'

--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -8,6 +8,7 @@ display:
           label: Otsikko
         type:
           label: Sisältötyyppi
+          separator: ', '
         name:
           label: Kirjoittaja
         status:

--- a/conf/cmi/language/fi/views.view.frontpage_news.yml
+++ b/conf/cmi/language/fi/views.view.frontpage_news.yml
@@ -10,3 +10,4 @@ display:
       title: 'Uusimmat uutiset'
       use_more_text: 'Katso kaikki uutiset'
       link_url: /uutiset
+    display_title: 'Uusimmat uutiset'

--- a/conf/cmi/language/fi/views.view.media_library.yml
+++ b/conf/cmi/language/fi/views.view.media_library.yml
@@ -4,6 +4,7 @@ display:
   default:
     display_title: Oletus
     display_options:
+      title: Media
       fields:
         media_bulk_form:
           action_title: Toiminto
@@ -15,6 +16,7 @@ display:
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'
+            offset_label: Offset
       exposed_form:
         options:
           submit_button: 'Suodata tuloksia'
@@ -61,6 +63,8 @@ display:
       fields:
         media_bulk_form:
           action_title: Toiminto
+        name:
+          separator: ', '
         edit_media:
           alter:
             text: 'Muokkaa {{ name }}'

--- a/conf/cmi/language/fi/views.view.news.yml
+++ b/conf/cmi/language/fi/views.view.news.yml
@@ -21,3 +21,5 @@ display:
             title: Kaikki
   latest_news:
     display_title: 'Uusimmat uutiset'
+    display_options:
+      title: 'Uusimmat uutiset'

--- a/conf/cmi/language/fi/views.view.news.yml
+++ b/conf/cmi/language/fi/views.view.news.yml
@@ -2,6 +2,12 @@ display:
   default:
     display_title: Oletus
     display_options:
+      title: 'Uusimmat uutiset'
+      fields:
+        published_at: {  }
+        field_main_image: {  }
+        view_node:
+          text: näkymä
       exposed_form:
         options:
           submit_button: Käytä
@@ -9,12 +15,6 @@ display:
           exposed_sorts_label: Lajittele
           sort_asc_label: Nousevasti
           sort_desc_label: Laskevasti
-      fields:
-        published_at: {  }
-        field_main_image: {  }
-        view_node:
-          text: näkymä
-      title: 'Uusimmat uutiset'
       arguments:
         nid:
           exception:
@@ -23,3 +23,5 @@ display:
     display_title: 'Uusimmat uutiset'
     display_options:
       title: 'Uusimmat uutiset'
+      use_more_text: 'Katso kaikki uutiset'
+      link_url: /uutiset

--- a/conf/cmi/language/sv/core.entity_view_mode.media.image.yml
+++ b/conf/cmi/language/sv/core.entity_view_mode.media.image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/field.field.media.image.field_media_image.yml
+++ b/conf/cmi/language/sv/field.field.media.image.field_media_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/field.field.paragraph.hero.field_hero_image.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.hero.field_hero_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/media.type.image.yml
+++ b/conf/cmi/language/sv/media.type.image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'Bild (stöds på andra språk)'

--- a/conf/cmi/language/sv/views.view.news.yml
+++ b/conf/cmi/language/sv/views.view.news.yml
@@ -2,18 +2,19 @@ display:
   default:
     display_title: Förvald
     display_options:
-      exposed_form:
-        options:
-          reset_button_label: Återställ
-          exposed_sorts_label: 'Sortera efter'
-          sort_asc_label: Stigande
-          sort_desc_label: Fallande
+      title: 'Senaste nyheterna'
       fields:
         published_at: {  }
         field_main_image: {  }
         view_node:
           text: visa
-      title: 'Senaste nyheterna'
+      exposed_form:
+        options:
+          submit_button: Verkställ
+          reset_button_label: Återställ
+          exposed_sorts_label: 'Sortera efter'
+          sort_asc_label: Stigande
+          sort_desc_label: Fallande
       arguments:
         nid:
           exception:
@@ -22,3 +23,5 @@ display:
     display_title: 'Senaste nyheterna'
     display_options:
       title: 'Senaste nyheterna'
+      use_more_text: 'Se alla nyheter'
+      link_url: /nyheter

--- a/conf/cmi/language/sv/views.view.news.yml
+++ b/conf/cmi/language/sv/views.view.news.yml
@@ -20,3 +20,5 @@ display:
             title: Alla
   latest_news:
     display_title: 'Senaste nyheterna'
+    display_options:
+      title: 'Senaste nyheterna'


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* UHF-X Add missing translation to latest news block title

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_latest-news-translation-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the news block title is now translated on any news item sidebar.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
