### PR TITLE
Drupal 10.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
+        "drupal/core": ">=10.2",
+        "drupal/core-composer-scaffold": ">=10.2",
+        "drupal/core-dev": ">=10.2",
         "drupal/drupal": "*"
     },
     "config": {


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Lock Drupal to 10.1.7 until issues with Drupal 10.2 have been fixed. See https://helsinkisolutionoffice.atlassian.net/browse/UHF-9488
