### PR TITLE
UHF-9575: adding distinct true removes duplicates from filtered rss feed

### DIFF
--- a/conf/cmi/views.settings.yml
+++ b/conf/cmi/views.settings.yml
@@ -1,7 +1,6 @@
 _core:
   default_config_hash: uZHsLrDp1ThO0RvupHKcPzLOyVvWexm58JTTHNDo7yc
 display_extenders: {  }
-skip_cache: false
 sql_signature: false
 ui:
   show:
@@ -46,3 +45,4 @@ field_rewrite_elements:
   ins: INS
   q: Q
   s: S
+skip_cache: false

--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -391,7 +391,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_lead_in'
@@ -1262,8 +1261,17 @@ display:
             content:
               views_rss_core:
                 encoded: ''
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
       defaults:
         access: true
+        query: false
         css_class: false
         relationships: false
         fields: false
@@ -1291,7 +1299,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - user
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_lead_in'


### PR DESCRIPTION
# [UHF-9575](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9575)
Remove duplicates from RSS feed

## What was done
Added distinct=true 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9575`
  * `make fresh`
* Run `make drush-cr`

## How to test
[helfi-etusivu.docker.so/fi/uutiset/rss?topic%5B0%5D=335&topic%5B1%5D=459&neighbourhoods%5B0%5D=420](https://www.hel.fi/fi/uutiset/rss?topic%5B0%5D=335&topic%5B1%5D=459&neighbourhoods%5B0%5D=420). You should not see any duplicates (duplicates were always subsequent)

* [ ] Check that this feature works
