### PR TITLE
UHF-9829: Main news admin views

### DIFF
--- a/public/modules/custom/helfi_etusivu/assets/css/views.css
+++ b/public/modules/custom/helfi_etusivu/assets/css/views.css
@@ -1,0 +1,23 @@
+/* Main news feed ordering -view highlight. */
+#views-form-ordered-news-list-ordered-news {
+  table tbody tr {
+    &:nth-child(-n+4) {
+      background: rgba(46,160,67,0.1);
+    }
+    &:nth-child(4) {
+      border-bottom: 1px solid rgba(0,0,0,0);
+    }
+  }
+}
+
+/* Main news article feed ordering -view highlight. */
+#views-form-ordered-news-articles-list-ordered-news-articles {
+  table tbody tr {
+    &:nth-child(-n+3) {
+      background: rgba(46,160,67,0.1);
+    }
+    &:nth-child(3) {
+      border-bottom: 1px solid rgba(0,0,0,0);
+    }
+  }
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.libraries.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.libraries.yml
@@ -10,3 +10,8 @@ menu-styles:
   css:
     theme:
       assets/css/menu.css: {}
+
+views-styles:
+  css:
+    theme:
+      assets/css/views.css: {}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -251,3 +251,21 @@ function helfi_etusivu_entity_insert(EntityInterface $entity) : void {
 function helfi_etusivu_helfi_hero_design_alter(array &$designs): void {
   $designs['with-search'] = t('With search');
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_etusivu_preprocess_page(&$variables): void {
+  $route = \Drupal::routeMatch()->getRouteName();
+  $ordered_news_list = [
+    'view.ordered_news_list.ordered_news',
+    'view.ordered_news_articles_list.ordered_news_articles',
+  ];
+
+  if (!in_array($route, $ordered_news_list)) {
+    return;
+  }
+
+  // Attach styles for the ordered news list and ordered news articles views.
+  $variables['#attached']['library'][] = 'helfi_etusivu/views-styles';
+}


### PR DESCRIPTION
# [UHF-9829](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9829)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved helfi-etusivu specific styles from hdbt-admin theme to etusivu instance.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9829_main_news_admin_views`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the colouring for https://helfi-etusivu.docker.so/fi/admin/ordered-news list still works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/281


[UHF-9829]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ