### PR TITLE
UHF-X: Use OGImageBuilder service for news node tokens

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -11,10 +11,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
-use Drupal\image\Entity\ImageStyle;
-use Drupal\media\MediaInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\ViewExecutable;
@@ -59,51 +56,6 @@ function helfi_etusivu_views_query_alter(ViewExecutable $view, QueryPluginBase $
       ];
     }
   }
-}
-
-/**
- * Implements hook_tokens().
- */
-function helfi_etusivu_tokens(
-  $type,
-  $tokens,
-  array $data,
-  array $options,
-  BubbleableMetadata $bubbleable_metadata
-) : array {
-  $replacements = [];
-
-  foreach ($tokens as $name => $original) {
-
-    // Custom token for shareable-image.
-    if ($name === 'shareable-image' && !empty($data['node'])) {
-      /** @var \Drupal\node\Entity\Node $node */
-      $node = $data['node'];
-
-      if (
-        $node->hasField('field_main_image') &&
-        isset($node->field_main_image->entity) &&
-        $node->field_main_image->entity instanceof MediaInterface &&
-        $node->field_main_image->entity->hasField('field_media_image')
-      ) {
-        $image_style = ImageStyle::load('og_image');
-
-        // If main image has an image set, use it as the shareable image.
-        // @phpstan-ignore-next-line
-        $image_entity = $node->get('field_main_image')->entity->field_media_image;
-
-        // Skip current entity if it's empty.
-        if ($image_entity->isEmpty()) {
-          break;
-        }
-
-        $image_path = $image_entity->entity->getFileUri();
-        $replacements[$original] = $image_style->buildUrl($image_path);
-      }
-    }
-  }
-
-  return $replacements;
 }
 
 /**

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
@@ -1,5 +1,5 @@
 services:
-  helfi_etusivu.og_image.node:
+  Drupal\helfi_etusivu\Token\NewsNodeImageBuilder:
     class: Drupal\helfi_etusivu\Token\NewsNodeImageBuilder
     tags:
       - { name: helfi_platform_config.og_image_builder }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
@@ -1,0 +1,5 @@
+services:
+  helfi_etusivu.og_image.node:
+    class: Drupal\helfi_etusivu\Token\NewsNodeImageBuilder
+    tags:
+      - { name: helfi_platform_config.og_image_builder }

--- a/public/modules/custom/helfi_etusivu/src/Token/NewsNodeImageBuilder.php
+++ b/public/modules/custom/helfi_etusivu/src/Token/NewsNodeImageBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\helfi_etusivu\Token;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\helfi_platform_config\Token\OGImageBuilderInterface;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * OG image for nodes.
+ */
+class NewsNodeImageBuilder implements OGImageBuilderInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function applies(?EntityInterface $entity): bool {
+    return $entity instanceof NodeInterface;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildUri(?EntityInterface $entity): ?string {
+    assert($entity instanceof NodeInterface);
+
+    if (
+      $entity->hasField('field_main_image') &&
+      isset($entity->field_main_image->entity) &&
+      $entity->field_main_image->entity instanceof MediaInterface &&
+      $entity->field_main_image->entity->hasField('field_media_image')
+    ) {
+      // If main image has an image set, use it as the shareable image.
+      // @phpstan-ignore-next-line
+      $image_entity = $entity->get('field_main_image')->entity->field_media_image;
+
+      // Skip current entity if it's empty.
+      if (!$image_entity->isEmpty()) {
+        return $image_entity->entity->getFileUri();
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/public/modules/custom/helfi_etusivu/src/Token/NewsNodeImageBuilder.php
+++ b/public/modules/custom/helfi_etusivu/src/Token/NewsNodeImageBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helfi_etusivu\Token;
 
 use Drupal\Core\Entity\EntityInterface;

--- a/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
+++ b/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
@@ -89,9 +89,9 @@ class NewsContentTypeTest extends ExistingSiteTestBase {
   }
 
   /**
-   * Metatag og:image should work with news_article.
+   * Metatag og:image should work with news content.
    */
-  public function testNewsArticleOgImage() : void {
+  public function testNewsOgImage() : void {
     $uri = $this->getTestFiles('image')[0]->uri;
 
     $file = File::create([
@@ -109,7 +109,7 @@ class NewsContentTypeTest extends ExistingSiteTestBase {
     $this->markEntityForCleanup($file);
 
     $node = $this->createNode([
-      'type' => 'news_article',
+      'type' => 'news_item',
       'status' => 1,
       'langcode' => 'fi',
       'field_main_image' => $media->id(),

--- a/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
+++ b/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
@@ -1,11 +1,14 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\dtt\ExistingSite;
 
 use Drupal\Core\Session\AccountInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
 use Drupal\Tests\helfi_api_base\Functional\ExistingSiteTestBase;
+use Drupal\Tests\TestFileCreationTrait;
 
 /**
  * Tests news endpoint.
@@ -13,6 +16,8 @@ use Drupal\Tests\helfi_api_base\Functional\ExistingSiteTestBase;
  * @group dtt
  */
 class NewsContentTypeTest extends ExistingSiteTestBase {
+
+  use TestFileCreationTrait;
 
   /**
    * The administrator account.
@@ -81,6 +86,37 @@ class NewsContentTypeTest extends ExistingSiteTestBase {
     // Test as anonymous.
     $this->drupalLogout();
     $this->assertJsonApiList();
+  }
+
+  /**
+   * Metatag og:image should work with news_article.
+   */
+  public function testNewsArticleOgImage() : void {
+    $uri = $this->getTestFiles('image')[0]->uri;
+
+    $file = File::create([
+      'uri' => $uri,
+    ]);
+    $file->save();
+    $this->markEntityForCleanup($file);
+
+    $media = Media::create([
+      'bundle' => 'image',
+      'name' => 'Custom name',
+      'field_media_image' => $file->id(),
+    ]);
+    $media->save();
+    $this->markEntityForCleanup($file);
+
+    $node = $this->createNode([
+      'type' => 'news_article',
+      'status' => 1,
+      'langcode' => 'fi',
+      'field_main_image' => $media->id(),
+    ]);
+
+    $this->drupalGet($node->toUrl());
+    $this->assertSession()->elementAttributeContains('css', 'meta[property="og:image"]', 'content', $file->getFilename());
   }
 
 }


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Cherry-pick 54028d5 from #572
* Use OGImageBuilder service for news nodes.
* Fix og images for news nodes.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-news-og-image`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/main/documentation/development.md#tokens
