### PR TITLE
UHF-9974: Robots.txt - Stricter rule for language query parameter

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -51,9 +51,12 @@ Disallow: /*?*neighbourhoods
 # Rekry job-search page query parameters, task_areas and page are allowed.
 Disallow: /*?*employment=*
 Disallow: /*?*keyword=*
-Disallow: /*?*language=*
 Disallow: /*?*continuous=*
 Disallow: /*?*internship=*
+# Language query parameter is used in css & js files.
+Disallow: /fi/avoimet-tyopaikat/*?*language=*
+Disallow: /sv/lediga-jobb/*?*language=*
+Disallow: /en/open-jobs/*?*language=*
 
 # Old robots
 #


### PR DESCRIPTION
# [UHF-9974](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9974)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Stricter robots.txt rules since language query parameter is used in css & js files: https://www.drupal.org/project/drupal/issues/1014086.

[UHF-9974]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ