### PR TITLE
UHF-10010: Unable to save unpublished translation 

### DIFF
--- a/conf/cmi/user.role.news_producer.yml
+++ b/conf/cmi/user.role.news_producer.yml
@@ -26,7 +26,7 @@ dependencies:
     - system
     - view_unpublished
 id: news_producer
-label: Uutistuottaja
+label: 'News producer'
 weight: 7
 is_admin: null
 permissions:

--- a/conf/cmi/user.role.news_producer.yml
+++ b/conf/cmi/user.role.news_producer.yml
@@ -24,8 +24,9 @@ dependencies:
     - publication_date
     - scheduler
     - system
+    - view_unpublished
 id: news_producer
-label: 'News producer'
+label: Uutistuottaja
 weight: 7
 is_admin: null
 permissions:
@@ -73,6 +74,7 @@ permissions:
   - 'use text format full_html'
   - 'use text format minimal'
   - 'view all media revisions'
+  - 'view any unpublished news_item content'
   - 'view editoria11y checker'
   - 'view news_item revisions'
   - 'view own unpublished content'


### PR DESCRIPTION
# [UHF-10010](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10010)
When news_producer tried to save unpublished translation, it failed with error `Either the path 'node/xxxx' is invalid or you do not have access to it.`
Check https://www.drupal.org/project/drupal/issues/3101344\#comment-13414279

## What was done
Added `view any unpublished news_item content` -permission to news producer

## How to reproduce
- Setup etusivu with production database
- drush uli --uid=53
- Go edit this node `sv/node/6226/edit`
- Try saving

Should fail with error.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10010`
  * `make fresh`
* Run `make drush-cr`

## How to test

- drush uli --uid=53
- Go edit this node `sv/node/6226/edit`
- Try saving

Saving should work, user should see the unpublished content page.

* [ ] Check that this feature works

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-10010]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ