### PR TITLE
UHF-9951: Nginx based elastic proxy

### DIFF
--- a/.env
+++ b/.env
@@ -25,4 +25,4 @@ DRUPAL_IMAGE=ghcr.io/city-of-helsinki/drupal-web:8.3
 DRUPAL_WEBROOT=public
 
 # Elastic url
-ELASTIC_PROXY_URL=https://elastic-helfi-etusivu.docker.so
+ELASTIC_PROXY_URL=https://elastic-proxy-helfi-etusivu.docker.so

--- a/compose.yaml
+++ b/compose.yaml
@@ -87,6 +87,27 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-varnish.tls=true"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}-varnish.loadbalancer.server.port=6081"
       - "traefik.docker.network=stonehenge-network"
+  elastic-proxy:
+    container_name: "${COMPOSE_PROJECT_NAME}-elastic-proxy"
+    image: nginx:alpine
+    environment:
+      ELASTICSEARCH_AUTHORIZATION: '${ELASTICSEARCH_AUTHORIZATION:-""}'
+    volumes:
+      - ./docker/local/elastic-proxy/templates:/etc/nginx/templates
+    networks:
+      - stonehenge-network
+      - internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nginx.entrypoints=https"
+      - "traefik.http.routers.nginx.rule=Host(`elastic-proxy-${DRUPAL_HOSTNAME}`)"
+      - "traefik.http.services.nginx.loadbalancer.server.port=8080"
+      - "traefik.http.routers.nginx.tls=true"
+      - "traefik.docker.network=stonehenge-network"
+    depends_on:
+      - elastic
+    profiles:
+      - search
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0
     container_name: "${COMPOSE_PROJECT_NAME}-elastic"

--- a/compose.yaml
+++ b/compose.yaml
@@ -92,7 +92,6 @@ services:
     image: nginxinc/nginx-unprivileged:alpine-perl
     environment:
       ELASTICSEARCH_URL: "http://elastic:9200"
-      RESOLVER_ADDRESS: 127.0.0.11
     volumes:
       - ./docker/elastic-proxy/nginx.conf:/etc/nginx/nginx.conf
       - ./docker/elastic-proxy/elastic.conf:/etc/nginx/templates/default.conf.template

--- a/compose.yaml
+++ b/compose.yaml
@@ -89,11 +89,10 @@ services:
       - "traefik.docker.network=stonehenge-network"
   elastic-proxy:
     container_name: "${COMPOSE_PROJECT_NAME}-elastic-proxy"
-    image: nginx:alpine
-    environment:
-      ELASTICSEARCH_AUTHORIZATION: '${ELASTICSEARCH_AUTHORIZATION:-""}'
+    image: openresty/openresty:alpine
     volumes:
-      - ./docker/local/elastic-proxy/templates:/etc/nginx/templates
+      - ./docker/elastic-proxy/nginx.conf:/etc/nginx/nginx.conf
+      - ./docker/elastic-proxy/elastic.conf:/etc/nginx/conf.d/default.conf
     networks:
       - stonehenge-network
       - internal

--- a/compose.yaml
+++ b/compose.yaml
@@ -89,10 +89,13 @@ services:
       - "traefik.docker.network=stonehenge-network"
   elastic-proxy:
     container_name: "${COMPOSE_PROJECT_NAME}-elastic-proxy"
-    image: openresty/openresty:alpine
+    image: nginxinc/nginx-unprivileged:alpine-perl
+    environment:
+      ELASTICSEARCH_URL: "http://elastic:9200"
+      RESOLVER_ADDRESS: 127.0.0.11
     volumes:
       - ./docker/elastic-proxy/nginx.conf:/etc/nginx/nginx.conf
-      - ./docker/elastic-proxy/elastic.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/elastic-proxy/elastic.conf:/etc/nginx/templates/default.conf.template
     networks:
       - stonehenge-network
       - internal

--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -10,7 +10,16 @@ server {
     location ~* /(ping|_msearch|_search)$ {
         proxy_pass http://elastic:9200;
         proxy_redirect off;
-        proxy_set_header  Authorization ${ELASTICSEARCH_AUTHORIZATION};
+        set_by_lua $authorization '
+          local user = os.getenv("ELASTIC_USER")
+          local pass = os.getenv("ELASTIC_PASSWORD")
+
+          if user == nil or pass == nil then
+            return ""
+          end
+          return ngx.encode_base64(user .. ":" .. pass)
+        ';
+        proxy_set_header  Authorization $authorization;
         proxy_pass_header Authorization;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -8,6 +8,9 @@ server {
     }
 
     location ~* /(ping|_msearch|_search)$ {
+        limit_except GET POST {
+           deny all;
+        }
         proxy_pass ${ELASTICSEARCH_URL};
         proxy_redirect off;
         proxy_set_header  Authorization $elastic_authorization;
@@ -18,7 +21,5 @@ server {
         proxy_pass_header Access-Control-Allow-Origin;
         proxy_pass_header Access-Control-Allow-Methods;
         proxy_hide_header Access-Control-Allow-Headers;
-        add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type';
-        add_header Access-Control-Allow-Credentials true;
     }
 }

--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -8,18 +8,9 @@ server {
     }
 
     location ~* /(ping|_msearch|_search)$ {
-        proxy_pass http://elastic:9200;
+        proxy_pass ${ELASTICSEARCH_URL};
         proxy_redirect off;
-        set_by_lua $authorization '
-          local user = os.getenv("ELASTIC_USER")
-          local pass = os.getenv("ELASTIC_PASSWORD")
-
-          if user == nil or pass == nil then
-            return ""
-          end
-          return ngx.encode_base64(user .. ":" .. pass)
-        ';
-        proxy_set_header  Authorization $authorization;
+        proxy_set_header  Authorization $elastic_authorization;
         proxy_pass_header Authorization;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/elastic-proxy/elastic.conf
+++ b/docker/elastic-proxy/elastic.conf
@@ -3,17 +3,18 @@ server {
     server_name _;
     client_max_body_size 50m;
 
-    location / {
-      return 500;
+    location /ping {
+      add_header Content-Type application/json;
+      return 200 '{"status":"success","result":"Proxy alive"}';
     }
 
-    location ~* /(ping|_msearch|_search)$ {
+    location ~* /(_msearch|_search)$ {
         limit_except GET POST {
            deny all;
         }
         proxy_pass ${ELASTICSEARCH_URL};
         proxy_redirect off;
-        proxy_set_header  Authorization $elastic_authorization;
+        proxy_set_header Authorization $elastic_authorization;
         proxy_pass_header Authorization;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/elastic-proxy/nginx.conf
+++ b/docker/elastic-proxy/nginx.conf
@@ -1,0 +1,89 @@
+# nginx.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/usr/local/openresty/nginx/conf/nginx.conf`
+# and is the file loaded by nginx at startup,
+# unless the user specifies otherwise.
+#
+# It tracks the upstream OpenResty's `nginx.conf`, but removes the `server`
+# section and adds this directive:
+#     `include /etc/nginx/conf.d/*.conf;`
+#
+# The `docker-openresty` file `nginx.vh.default.conf` is copied to
+# `/etc/nginx/conf.d/default.conf`.  It contains the `server section
+# of the upstream `nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+#user  nobody;
+#worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+pid        /tmp/nginx.pid;
+
+# Expose elastic user+password.
+env ELASTIC_USER;
+env ELASTIC_PASSWORD;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    # Enables or disables the use of underscores in client request header fields.
+    # When the use of underscores is disabled, request header fields whose names contain underscores are marked as invalid and become subject to the ignore_invalid_headers directive.
+    # underscores_in_headers off;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+    # Log in JSON Format
+    log_format nginxlog_json escape=json '{ "timestamp": "$time_iso8601", '
+      '"remote_addr": "$remote_addr", '
+      '"body_bytes_sent": $body_bytes_sent, '
+      '"request_time": $request_time, '
+      '"response_status": $status, '
+      '"request": "$request", '
+      '"request_method": "$request_method", '
+      '"host": "$host",'
+      '"upstream_addr": "$upstream_addr",'
+      '"http_x_forwarded_for": "$http_x_forwarded_for",'
+      '"http_referrer": "$http_referer", '
+      '"http_user_agent": "$http_user_agent", '
+      '"http_version": "$server_protocol", '
+      '"nginx_access": true }';
+    access_log /dev/stdout nginxlog_json;
+
+    # See Move default writable paths to a dedicated directory (#119)
+    # https://github.com/openresty/docker-openresty/issues/119
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    # Don't reveal OpenResty version to clients.
+    server_tokens off;
+}

--- a/docker/elastic-proxy/nginx.conf
+++ b/docker/elastic-proxy/nginx.conf
@@ -1,53 +1,36 @@
-# nginx.conf  --  docker-openresty
-#
-# This file is installed to:
-#   `/usr/local/openresty/nginx/conf/nginx.conf`
-# and is the file loaded by nginx at startup,
-# unless the user specifies otherwise.
-#
-# It tracks the upstream OpenResty's `nginx.conf`, but removes the `server`
-# section and adds this directive:
-#     `include /etc/nginx/conf.d/*.conf;`
-#
-# The `docker-openresty` file `nginx.vh.default.conf` is copied to
-# `/etc/nginx/conf.d/default.conf`.  It contains the `server section
-# of the upstream `nginx.conf`.
-#
-# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
-#
+worker_processes  auto;
 
-#user  nobody;
-#worker_processes 1;
-
-# Enables the use of JIT for regular expressions to speed-up their processing.
-pcre_jit on;
-#error_log  logs/error.log;
-#error_log  logs/error.log  notice;
-#error_log  logs/error.log  info;
-
+error_log  /var/log/nginx/error.log notice;
 pid        /tmp/nginx.pid;
 
-# Expose elastic user+password.
-env ELASTIC_USER;
+env ELASTICSEARCH_URL;
 env ELASTIC_PASSWORD;
+env ELASTIC_USER;
+
+load_module modules/ngx_http_perl_module.so;
 
 events {
     worker_connections  1024;
 }
 
 http {
-    include       mime.types;
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-
-    # Enables or disables the use of underscores in client request header fields.
-    # When the use of underscores is disabled, request header fields whose names contain underscores are marked as invalid and become subject to the ignore_invalid_headers directive.
-    # underscores_in_headers off;
-
-    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    #                  '$status $body_bytes_sent "$http_referer" '
-    #                  '"$http_user_agent" "$http_x_forwarded_for"';
-
-    #access_log  logs/access.log  main;
+    perl_set $elastic_authorization '
+      sub {
+        use MIME::Base64;
+        if (exists($ENV{"ELASTIC_USER"}) && exists($ENV{"ELASTIC_PASSWORD"})) {
+          return encode_base64($ENV{"ELASTIC_USER"} . ":" . $ENV{"ELASTIC_PASSWORD"});
+        }
+        return "";
+      }
+    ';
 
     # Log in JSON Format
     log_format nginxlog_json escape=json '{ "timestamp": "$time_iso8601", '
@@ -66,24 +49,12 @@ http {
       '"nginx_access": true }';
     access_log /dev/stdout nginxlog_json;
 
-    # See Move default writable paths to a dedicated directory (#119)
-    # https://github.com/openresty/docker-openresty/issues/119
-    client_body_temp_path /var/run/openresty/nginx-client-body;
-    proxy_temp_path       /var/run/openresty/nginx-proxy;
-    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
-    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
-    scgi_temp_path        /var/run/openresty/nginx-scgi;
-
     sendfile        on;
     #tcp_nopush     on;
 
-    #keepalive_timeout  0;
     keepalive_timeout  65;
 
     #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
-
-    # Don't reveal OpenResty version to clients.
-    server_tokens off;
 }

--- a/docker/local/elastic-proxy/templates/elastic.conf.template
+++ b/docker/local/elastic-proxy/templates/elastic.conf.template
@@ -1,0 +1,24 @@
+server {
+    listen 8080 default_server;
+    server_name _;
+    client_max_body_size 50m;
+
+    location / {
+      return 500;
+    }
+
+    location ~* /(ping|_msearch|_search)$ {
+        proxy_pass http://elastic:9200;
+        proxy_redirect off;
+        proxy_set_header  Authorization ${ELASTICSEARCH_AUTHORIZATION};
+        proxy_pass_header Authorization;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_pass_header Access-Control-Allow-Origin;
+        proxy_pass_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type';
+        add_header Access-Control-Allow-Credentials true;
+    }
+}


### PR DESCRIPTION
## How to install
- `git checkout UHF-9951`
- `make stop && make up`

## How to test
- [x] Make sure queries can be proxied through https://elastic-proxy-helfi-etusivu.docker.so/{index}/_search and https://elastic-proxy-helfi-etusivu.docker.so/{index}/_msearch URLs