### PR TITLE
UHF-9739:  News update admin user interface improvements

### DIFF
--- a/conf/cmi/language/fi/core.entity_form_display.node.news_item.default.yml
+++ b/conf/cmi/language/fi/core.entity_form_display.node.news_item.default.yml
@@ -9,7 +9,7 @@ third_party_settings:
     group_updating_news:
       label: 'Päivittyvä uutinen'
       format_settings:
-        description: 'Jätä sisältöalue tyhjäksi päivittyvän uutisen yläpuolelta, jos luot päivittyvän uutisen.<br />Lisää uusin uutispäivitys viimeiseksi. Järjestelmä näyttää päivitykset sivulla käänteisessä järjestyksessä.'
+        description: 'Jätä sisältöalue tyhjäksi päivittyvän uutisen yläpuolelta, jos luot päivittyvän uutisen.<br />Lisää uusin uutispäivitys viimeiseksi. Verkkosivulla uutispäivitykset näytetään lukijalle uusimmasta vanhimpaan.'
 content:
   field_content:
     settings:

--- a/public/modules/custom/helfi_etusivu_config/config/rewrite/language/fi/core.entity_form_display.node.news_item.default.yml
+++ b/public/modules/custom/helfi_etusivu_config/config/rewrite/language/fi/core.entity_form_display.node.news_item.default.yml
@@ -3,4 +3,4 @@ third_party_settings:
     group_updating_news:
       label: 'Päivittyvä uutinen'
       format_settings:
-        description: "Jätä sisältöalue tyhjäksi päivittyvän uutisen yläpuolelta, jos luot päivittyvän uutisen.<br />Lisää uusin uutispäivitys viimeiseksi. Järjestelmä näyttää päivitykset sivulla käänteisessä järjestyksessä."
+        description: "Jätä sisältöalue tyhjäksi päivittyvän uutisen yläpuolelta, jos luot päivittyvän uutisen.<br />Lisää uusin uutispäivitys viimeiseksi. Verkkosivulla uutispäivitykset näytetään lukijalle uusimmasta vanhimpaan."


### PR DESCRIPTION
# [UHF-9739](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9739)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Adjust translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9739_adjustments`
  * `make fresh`
* Make sure to checkout hdbt_admin to the same branch as well:
  * `composer require drupal/hdbt_admin:dev-UHF-9739`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the translations are correct according to the comments in this PR: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9739
* [x] Test that the updating news block with banner paragraph doesn't cause the layout to break with very narrow screens like it does not in the testing: https://www.test.hel.ninja/fi/node/6352/edit
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/284
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/623


[UHF-9739]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ