### PR TITLE
UHF-9962 recommendations algorithm

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_aipoweredrecommendations.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_aipoweredrecommendations.yml
@@ -1,6 +1,6 @@
 uuid: 6ab1786a-6f04-44a4-afe2-b7c9829fd000
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - helfi_annif

--- a/public/modules/custom/helfi_annif/config/install/block.block.hdbt_subtheme_aipoweredrecommendations.yml
+++ b/public/modules/custom/helfi_annif/config/install/block.block.hdbt_subtheme_aipoweredrecommendations.yml
@@ -1,0 +1,40 @@
+uuid: 6ab1786a-6f04-44a4-afe2-b7c9829fd000
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_annif
+    - language
+    - node
+  theme:
+    - hdbt_subtheme
+id: hdbt_subtheme_aipoweredrecommendations
+theme: hdbt_subtheme
+region: content
+weight: 0
+provider: null
+plugin: helfi_recommendations
+settings:
+  id: helfi_recommendations
+  label: 'AI powered recommendations'
+  label_display: visible
+  provider: helfi_annif
+  context_mapping:
+    node: '@node.node_route_context:node'
+visibility:
+  language:
+    id: language
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_interface'
+    langcodes:
+      fi: fi
+      sv: sv
+      en: en
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      news_item: news_item

--- a/public/modules/custom/helfi_annif/helfi_annif.module
+++ b/public/modules/custom/helfi_annif/helfi_annif.module
@@ -12,6 +12,22 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\helfi_annif\KeywordManager;
 use Drupal\helfi_annif\TextConverter\Document;
 
+
+
+/**
+ * Implements hook_theme().
+ */
+function helfi_annif_theme() : array {
+  return [
+    'recommendations_block' => [
+      'variables' => [
+        'rows' => NULL,
+      ],
+      'template' => 'recommendations-block',
+    ],
+  ];
+}
+
 /**
  * Implements hook_entity_insert().
  */

--- a/public/modules/custom/helfi_annif/helfi_annif.module
+++ b/public/modules/custom/helfi_annif/helfi_annif.module
@@ -12,8 +12,6 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\helfi_annif\KeywordManager;
 use Drupal\helfi_annif\TextConverter\Document;
 
-
-
 /**
  * Implements hook_theme().
  */

--- a/public/modules/custom/helfi_annif/helfi_annif.services.yml
+++ b/public/modules/custom/helfi_annif/helfi_annif.services.yml
@@ -9,9 +9,7 @@ services:
 
   Drupal\helfi_annif\KeywordManager: ~
 
-  helfi_annif.recommendation_manager:
-    class: Drupal\helfi_annif\RecommendationManager
-    autowire: true
+  Drupal\helfi_annif\RecommendationManager: ~
 
   Drupal\helfi_annif\Client\KeywordClient: ~
 

--- a/public/modules/custom/helfi_annif/helfi_annif.services.yml
+++ b/public/modules/custom/helfi_annif/helfi_annif.services.yml
@@ -3,9 +3,15 @@ services:
     autowire: true
     autoconfigure: true
 
+  logger.channel.helfi_annif:
+    parent: logger.channel_base
+    arguments: ['helfi_annif']
+
   Drupal\helfi_annif\KeywordManager: ~
 
-  Drupal\helfi_annif\RecommendationManager: ~
+  helfi_annif.recommendation_manager:
+    class: Drupal\helfi_annif\RecommendationManager
+    autowire: true
 
   Drupal\helfi_annif\Client\KeywordClient: ~
 

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -127,7 +127,8 @@ final class KeywordManager {
       return;
     }
 
-    $this->saveKeywords($entity, $this->keywordGenerator->suggest($entity));
+    $keywords = $this->keywordGenerator->suggest($entity) ?? [];
+    $this->saveKeywords($entity, $keywords);
   }
 
   /**

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_annif\Plugin\Block;
 
-use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -45,7 +45,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : static {
     return new static($configuration, $plugin_id, $plugin_definition,
-      $container->get('helfi_annif.recommendation_manager'),
+      $container->get(RecommendationManager::class),
       $container->get('current_user'),
       $container->get('logger.channel.helfi_annif'),
     );

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Drupal\helfi_annif\Plugin\Block;
 
 use Drupal\Component\Plugin\Exception\ContextException;
-use Drupal\Core\Annotation\ContextDefinition;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
-use Drupal\Core\Plugin\Context\EntityContextDefinition;
-use Drupal\Core\Plugin\ContextAwarePluginAssignmentTrait;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
-use Drupal\Core\Plugin\ContextAwarePluginTrait;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_annif\RecommendationManager;
 use Psr\Log\LoggerAwareInterface;
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   id: "helfi_recommendations",
   admin_label: new TranslatableMarkup("AI powered recommendations"),
   context_definitions: [
-    'node' => new \Drupal\Core\Plugin\Context\ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE)
+    'node' => new ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE)
   ]
 )]
 class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, LoggerAwareInterface, ContextAwarePluginInterface {
@@ -39,7 +39,8 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
     $plugin_id,
     $plugin_definition,
     private readonly ContextRepositoryInterface $contextRepository,
-    private readonly RecommendationManager $recommendationManager
+    private readonly RecommendationManager $recommendationManager,
+    private readonly AccountInterface $currentUser
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -50,7 +51,8 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : static {
     return new static($configuration, $plugin_id, $plugin_definition,
       $container->get('context.repository'),
-      $container->get('helfi_annif.recommendation_manager')
+      $container->get('helfi_annif.recommendation_manager'),
+      $container->get('current_user')
     );
   }
 
@@ -58,22 +60,63 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
    * {@inheritdoc}
    */
   public function build() : array {
-    $x = 1;
     try {
       $node = $this->getContextValue('node');
-      $results = $this->recommendationManager->getRecommendations($node);
     }
     catch (ContextException $exception) {
-      $x = 1;
-      // $this->logger->error($exception->getMessage());
+      $this->logger->error($exception->getMessage());
+      return [];
+    }
+    // @TODO: #UHF-9964 Lisätään suosittelulohkon piilotustoiminto.
+
+    $response = $this->getResponseArray($node);
+    $recommendations = $this->recommendationManager->getRecommendations($node);
+    if (!$recommendations) {
+      return $this->handleNoRecommendations($response);
+    }
+
+    $response['#recommendations'] = $recommendations;
+    return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts(): array {
+    return Cache::mergeContexts(parent::getCacheContexts(), ['languages:language_content']);
+  }
+
+  /**
+   * Return response when recommendations are not yet calculated.
+   *
+   * @param array $response
+   *   Render array.
+   *
+   * @return array
+   *   Render array.
+   */
+  private function handleNoRecommendations(array $response): array {
+    if ($this->currentUser->isAnonymous()) {
       return [];
     }
 
+    $response['#no_results_message'] = $this->t('Calculating recommendations');
+    return $response;
+  }
 
-
-    // @todo UHF-9962.
+  /**
+   * Get initial render array.
+   *
+   * @return array
+   *   Render array.
+   */
+  private function getResponseArray(EntityInterface $node): array {
     return [
-      '#markup' => $this->t('Hello, World!'),
+      '#theme' => 'recommendations_block',
+      '#title' => $this->t('You might be interested in'),
+      '#cache' => [
+        'tags' => "{$node->getEntityTypeId()}:{$node->id()}",
+      ]
     ];
   }
 

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -4,9 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_annif\Plugin\Block;
 
+use Drupal\Component\Plugin\Exception\ContextException;
+use Drupal\Core\Annotation\ContextDefinition;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Plugin\ContextAwarePluginAssignmentTrait;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Plugin\ContextAwarePluginTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\helfi_annif\RecommendationManager;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides 'AI powered recommendations'.
@@ -14,13 +26,51 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[Block(
   id: "helfi_recommendations",
   admin_label: new TranslatableMarkup("AI powered recommendations"),
+  context_definitions: [
+    'node' => new \Drupal\Core\Plugin\Context\ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE)
+  ]
 )]
-class RecommendationsBlock extends BlockBase {
+class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, LoggerAwareInterface, ContextAwarePluginInterface {
+
+  use LoggerAwareTrait;
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly ContextRepositoryInterface $contextRepository,
+    private readonly RecommendationManager $recommendationManager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : static {
+    return new static($configuration, $plugin_id, $plugin_definition,
+      $container->get('context.repository'),
+      $container->get('helfi_annif.recommendation_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() : array {
+    $x = 1;
+    try {
+      $node = $this->getContextValue('node');
+      $results = $this->recommendationManager->getRecommendations($node);
+    }
+    catch (ContextException $exception) {
+      $x = 1;
+      // $this->logger->error($exception->getMessage());
+      return [];
+    }
+
+
+
     // @todo UHF-9962.
     return [
       '#markup' => $this->t('Hello, World!'),

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -59,19 +59,12 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public function build() : array {
-    try {
-      $node = $this->getContextValue('node');
-    }
-    catch (ContextException $exception) {
-      $this->logger->error($exception->getMessage());
-      return [];
-    }
+    $node = $this->getContextValue('node');
 
     // @todo #UHF-9964 Lisätään suosittelulohkon piilotustoiminto.
     $response = [
       '#theme' => 'recommendations_block',
       '#title' => $this->t('You might be interested in'),
-      '#cache' => ['tags' => ["{$node->getEntityTypeId()}:{$node->id()}"]],
     ];
 
     $recommendations = $this->recommendationManager->getRecommendations($node);
@@ -88,6 +81,10 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
    */
   public function getCacheContexts(): array {
     return Cache::mergeContexts(parent::getCacheContexts(), ['languages:language_content']);
+  }
+
+  public function getCacheTags(): array {
+    return Cache::mergeTags(parent::getCacheTags(), $this->getContextValue('node')->getCacheTags());
   }
 
   /**

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -25,8 +25,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   admin_label: new TranslatableMarkup("AI powered recommendations"),
   context_definitions: [
     'node' => new EntityContextDefinition(
-      data_type:'node',
-      label:new TranslatableMarkup('Node'),
+      data_type: 'node',
+      label: new TranslatableMarkup('Node'),
       required: TRUE,
     ),
   ]

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   id: "helfi_recommendations",
   admin_label: new TranslatableMarkup("AI powered recommendations"),
   context_definitions: [
-    'node' => new ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE),
+    'node' => new ContextDefinition('node', new TranslatableMarkup('Node'), FALSE),
   ]
 )]
 final class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -9,7 +9,7 @@ use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -24,7 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   id: "helfi_recommendations",
   admin_label: new TranslatableMarkup("AI powered recommendations"),
   context_definitions: [
-    'node' => new ContextDefinition('node', new TranslatableMarkup('Node'), FALSE),
+    'node' => new EntityContextDefinition(
+      data_type:'node',
+      label:new TranslatableMarkup('Node'),
+      required: TRUE,
+    ),
   ]
 )]
 final class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -69,8 +69,8 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
     // @todo #UHF-9964 Lisätään suosittelulohkon piilotustoiminto.
     $response = [
       '#theme' => 'recommendations_block',
-          '#title' => $this->t('You might be interested in'),
-          '#cache' => ['tags' => ["{$node->getEntityTypeId()}:{$node->id()}"]],
+      '#title' => $this->t('You might be interested in'),
+      '#cache' => ['tags' => ["{$node->getEntityTypeId()}:{$node->id()}"]],
     ];
 
     $recommendations = $this->recommendationManager->getRecommendations($node);

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -10,7 +10,6 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\Context\ContextDefinition;
-use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -28,13 +27,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
     'node' => new ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE),
   ]
 )]
-class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {
+final class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {
 
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private readonly ContextRepositoryInterface $contextRepository,
     private readonly RecommendationManager $recommendationManager,
     private readonly AccountInterface $currentUser,
     private readonly LoggerInterface $logger,
@@ -47,7 +45,6 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : static {
     return new static($configuration, $plugin_id, $plugin_definition,
-      $container->get('context.repository'),
       $container->get('helfi_annif.recommendation_manager'),
       $container->get('current_user'),
       $container->get('logger.channel.helfi_annif'),

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -8,7 +8,6 @@ use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
@@ -67,13 +66,11 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
       return [];
     }
 
-    // @TODO: #UHF-9964 Lisätään suosittelulohkon piilotustoiminto.
+    // @todo #UHF-9964 Lisätään suosittelulohkon piilotustoiminto.
     $response = [
       '#theme' => 'recommendations_block',
-        '#title' => $this->t('You might be interested in'),
-        '#cache' => [
-        'tags' => ["{$node->getEntityTypeId()}:{$node->id()}"],
-      ]
+          '#title' => $this->t('You might be interested in'),
+          '#cache' => ['tags' => ["{$node->getEntityTypeId()}:{$node->id()}"]],
     ];
 
     $recommendations = $this->recommendationManager->getRecommendations($node);

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -115,7 +115,7 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
       '#theme' => 'recommendations_block',
       '#title' => $this->t('You might be interested in'),
       '#cache' => [
-        'tags' => "{$node->getEntityTypeId()}:{$node->id()}",
+        'tags' => ["{$node->getEntityTypeId()}:{$node->id()}"],
       ]
     ];
   }

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -17,7 +17,8 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_annif\RecommendationManager;
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -30,9 +31,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
     'node' => new ContextDefinition('entity:node', new TranslatableMarkup('Node'), FALSE)
   ]
 )]
-class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, LoggerAwareInterface, ContextAwarePluginInterface {
-
-  use LoggerAwareTrait;
+class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {
 
   public function __construct(
     array $configuration,
@@ -40,7 +39,8 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
     $plugin_definition,
     private readonly ContextRepositoryInterface $contextRepository,
     private readonly RecommendationManager $recommendationManager,
-    private readonly AccountInterface $currentUser
+    private readonly AccountInterface $currentUser,
+    private readonly LoggerInterface $logger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -52,7 +52,8 @@ class RecommendationsBlock extends BlockBase implements ContainerFactoryPluginIn
     return new static($configuration, $plugin_id, $plugin_definition,
       $container->get('context.repository'),
       $container->get('helfi_annif.recommendation_manager'),
-      $container->get('current_user')
+      $container->get('current_user'),
+      $container->get('logger.channel.helfi_annif'),
     );
   }
 

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -83,6 +83,9 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
     return Cache::mergeContexts(parent::getCacheContexts(), ['languages:language_content']);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheTags(): array {
     return Cache::mergeTags(parent::getCacheTags(), $this->getContextValue('node')->getCacheTags());
   }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -41,7 +41,6 @@ class RecommendationManager implements LoggerAwareInterface {
    *   Array of recommendations.
    */
   public function getRecommendations(EntityInterface $node): array {
-
     // @todo #UHF-9964 exclude unwanted keywords and entities and refactor.
     $query = "
       select
@@ -54,9 +53,9 @@ class RecommendationManager implements LoggerAwareInterface {
           field_annif_keywords_target_id
           from node__field_annif_keywords
           where entity_id = :nid and
-          langcode = 'fi')
-      and n.langcode = 'fi'
-      and annif.langcode = 'fi'
+          langcode = :langcode)
+      and n.langcode = :langcode
+      and annif.langcode = :langcode
       and n.nid != :nid
       group by n.nid
       order by relevancy DESC
@@ -65,7 +64,9 @@ class RecommendationManager implements LoggerAwareInterface {
 
     $response = [];
     try {
-      $results = $this->connection->query($query, [':nid' => $node->id()])->fetchAll();
+
+
+      $results = $this->connection->query($query, [':nid' => $node->id(), ':langcode' => $node->get('langcode')->value])->fetchAll();
     }
     catch (\Exception $e) {
       $this->logger->error($e->getMessage());

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -21,18 +21,20 @@ class RecommendationManager implements LoggerAwareInterface {
    * The constructor.
    *
    * @param EntityTypeManagerInterface $entityManager
+   *   The entity type manager.
    * @param Connection $connection
+   *   The connection.
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityManager,
-    private readonly Connection $connection
+    private readonly Connection $connection,
   ) {
   }
 
   /**
    * Get recommendations for a node.
    *
-   * @param EntityInterface $node
+   * @param Drupal\Core\Entity\EntityInterface $node
    *   The node
    *
    * @return array
@@ -40,7 +42,7 @@ class RecommendationManager implements LoggerAwareInterface {
    */
   public function getRecommendations(EntityInterface $node): array {
 
-    // @TODO: #UHF-9964 exclude unwanted.
+    // @todo: #UHF-9964 exclude unwanted keywords and entities and refactor.
     $query = "
       select
          n.nid,
@@ -65,7 +67,7 @@ class RecommendationManager implements LoggerAwareInterface {
     try {
       $results = $this->connection->query($query, [':nid' => $node->id()])->fetchAll();
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       $this->logger->error($e->getMessage());
       return $response;
     }
@@ -81,7 +83,7 @@ class RecommendationManager implements LoggerAwareInterface {
         ->getStorage($node->getEntityTypeId())
         ->loadMultiple($nids);
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       $this->logger->error($e->getMessage());
       return [];
     }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -20,9 +20,9 @@ class RecommendationManager implements LoggerAwareInterface {
   /**
    * The constructor.
    *
-   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entityManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityManager
    *   The entity type manager.
-   * @param Drupal\Core\Database\Connection $connection
+   * @param \Drupal\Core\Database\Connection $connection
    *   The connection.
    */
   public function __construct(
@@ -34,7 +34,7 @@ class RecommendationManager implements LoggerAwareInterface {
   /**
    * Get recommendations for a node.
    *
-   * @param Drupal\Core\Entity\EntityInterface $node
+   * @param \Drupal\Core\Entity\EntityInterface $node
    *   The node.
    *
    * @return array

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection SqlDialectInspection */
+<?php
 
 declare(strict_types=1);
 
@@ -20,9 +20,9 @@ class RecommendationManager implements LoggerAwareInterface {
   /**
    * The constructor.
    *
-   * @param EntityTypeManagerInterface $entityManager
+   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entityManager
    *   The entity type manager.
-   * @param Connection $connection
+   * @param Drupal\Core\Database\Connection $connection
    *   The connection.
    */
   public function __construct(
@@ -35,14 +35,14 @@ class RecommendationManager implements LoggerAwareInterface {
    * Get recommendations for a node.
    *
    * @param Drupal\Core\Entity\EntityInterface $node
-   *   The node
+   *   The node.
    *
    * @return array
-   *   Array of recommendations
+   *   Array of recommendations.
    */
   public function getRecommendations(EntityInterface $node): array {
 
-    // @todo: #UHF-9964 exclude unwanted keywords and entities and refactor.
+    // @todo #UHF-9964 exclude unwanted keywords and entities and refactor.
     $query = "
       select
          n.nid,

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -64,7 +64,7 @@ class RecommendationManager implements LoggerAwareInterface {
 
     $response = [];
     try {
-      $results = $this->connection->query($query, [':nid' => $node->id(), ':langcode' => $node->get('langcode')->value])->fetchAll();
+      $results = $this->connection->query($query, [':nid' => $node->id(), ':langcode' => $node->language()->getId()])->fetchAll();
     }
     catch (\Exception $e) {
       $this->logger->error($e->getMessage());

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -40,6 +40,7 @@ class RecommendationManager implements LoggerAwareInterface {
    */
   public function getRecommendations(EntityInterface $node): array {
 
+    // @TODO: #UHF-9964 exclude unwanted.
     $query = "
       select
          n.nid,

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -61,16 +61,23 @@ class RecommendationManager implements LoggerAwareInterface {
       limit 4;
     ";
 
-    $results = $this->connection->query($query, [':nid' => $node->id()])->fetchAll();
+    $response = [];
+    try {
+      $results = $this->connection->query($query, [':nid' => $node->id()])->fetchAll();
+    }
+    catch(\Exception $e) {
+      $this->logger->error($e->getMessage());
+      return $response;
+    }
 
     if (!$results || !is_array($results)) {
-      return [];
+      return $response;
     }
 
     $nids = array_column($results, 'nid');
 
     try {
-      $entities = $this->entityManager
+      $response = $this->entityManager
         ->getStorage($node->getEntityTypeId())
         ->loadMultiple($nids);
     }
@@ -79,7 +86,7 @@ class RecommendationManager implements LoggerAwareInterface {
       return [];
     }
 
-    return $entities;
+    return $response;
   }
 
 }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -60,7 +60,7 @@ class RecommendationManager implements LoggerAwareInterface {
       and n.nid != :nid
       group by n.nid
       order by relevancy DESC
-      limit 4;
+      limit 3;
     ";
 
     $response = [];

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -1,13 +1,84 @@
-<?php
+<?php /** @noinspection SqlDialectInspection */
 
 declare(strict_types=1);
 
 namespace Drupal\helfi_annif;
 
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
 /**
  * The recommendation manager.
- *
- * @todo UHF-9962.
  */
-class RecommendationManager {
+class RecommendationManager implements LoggerAwareInterface {
+
+  use LoggerAwareTrait;
+
+  /**
+   * The constructor.
+   *
+   * @param EntityTypeManagerInterface $entityManager
+   * @param Connection $connection
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityManager,
+    private readonly Connection $connection
+  ) {
+  }
+
+  /**
+   * Get recommendations for a node.
+   *
+   * @param EntityInterface $node
+   *   The node
+   *
+   * @return array
+   *   Array of recommendations
+   */
+  public function getRecommendations(EntityInterface $node): array {
+
+    $query = "
+      select
+         n.nid,
+         count(n.nid) as relevancy
+      from node as n
+      left join node__field_annif_keywords as annif on n.nid = annif.entity_id
+      where annif.field_annif_keywords_target_id in
+         (select
+          field_annif_keywords_target_id
+          from node__field_annif_keywords
+          where entity_id = :nid and
+          langcode = 'fi')
+      and n.langcode = 'fi'
+      and annif.langcode = 'fi'
+      and n.nid != :nid
+      group by n.nid
+      order by relevancy DESC
+      limit 4;
+    ";
+
+    $results = $this->connection->query($query, [':nid' => $node->id()])->fetchAll();
+
+    if (!$results || !is_array($results)) {
+      return [];
+    }
+
+    $nids = array_column($results, 'nid');
+
+    try {
+      $entities = $this->entityManager
+        ->getStorage($node->getEntityTypeId())
+        ->loadMultiple($nids);
+    }
+    catch(\Exception $e) {
+      $this->logger->error($e->getMessage());
+      return [];
+    }
+
+    return $entities;
+  }
+
 }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -64,8 +64,6 @@ class RecommendationManager implements LoggerAwareInterface {
 
     $response = [];
     try {
-
-
       $results = $this->connection->query($query, [':nid' => $node->id(), ':langcode' => $node->get('langcode')->value])->fetchAll();
     }
     catch (\Exception $e) {

--- a/public/modules/custom/helfi_annif/templates/recommendations-block.html.twig
+++ b/public/modules/custom/helfi_annif/templates/recommendations-block.html.twig
@@ -1,0 +1,7 @@
+<ul class="news-listing news-listing--latest-tiny-teasers">
+  {% for row in rows %}
+    <li class="news-listing__item">
+      {{ drupal_entity('node', row.nid.value, 'card_teaser') }}
+    </li>
+  {% endfor %}
+</ul>

--- a/public/modules/custom/helfi_annif/templates/recommendations-block.html.twig
+++ b/public/modules/custom/helfi_annif/templates/recommendations-block.html.twig
@@ -1,7 +1,31 @@
-<ul class="news-listing news-listing--latest-tiny-teasers">
-  {% for row in rows %}
-    <li class="news-listing__item">
-      {{ drupal_entity('node', row.nid.value, 'card_teaser') }}
-    </li>
-  {% endfor %}
-</ul>
+{% for row in rows %}
+  {# Created date and modified date #}
+  {% set published_at = row.published_at.value  %}
+  {% if published_at is not empty %}
+    {% set html_published_at  %}
+      <time datetime="{{ published_at|format_date('custom', 'Y-m-d') ~ 'T' ~ published_at|format_date('custom', 'H:i') }}" class="news-listing__datetime news-listing__datetime--published" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+        <span class="visually-hidden">{{ 'Published'|t({}, {'context': 'The helper text before the node published timestamp'}) }}</span>
+        {{ published_at|format_date('publication_date_format') }}
+      </time>
+    {% endset %}
+  {% else %}
+    {% set html_published_at = '-' %}
+  {% endif %}
+
+  {% set card_url = url('entity.node.canonical', {'node': row.id})['#markup'] %}
+
+  {% embed '@hdbt/component/card.twig' with {
+    card_modifier_class: 'news-listing__item',
+    card_title_level: 'h3',
+    card_title: row.title.value,
+    card_url: card_url,
+    card_metas: [
+      {
+        icon: 'clock',
+        label: 'Published'|t({}, {'context': 'Label for news card published time'}),
+        content: html_published_at
+      },
+    ],
+  } %}
+  {% endembed %}
+{% endfor %}

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--helfi-annif.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--helfi-annif.html.twig
@@ -1,0 +1,14 @@
+{% block paragraph %}
+  {% embed "@hdbt/misc/component.twig" with
+    {
+      component_classes: [ 'component--recommendations' ],
+      component_title: 'You might be interested in'|t({}, {'context': 'Front page recommendations block title'}),
+      use_component_title_lang_fallback: alternative_language ?? false,
+      component_content_class: 'recommendations',
+    }
+  %}
+    {% block component_content %}
+      {{ content }}
+    {% endblock component_content %}
+  {% endembed %}
+{% endblock paragraph %}

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--helfi-recommendationsssss.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--helfi-recommendationsssss.html.twig
@@ -1,0 +1,7 @@
+<ul class="news-listing news-listing--latest-tiny-teasers">
+  {% for row in content.rows %}
+    <li class="news-listing__item">
+      {{- row.content -}}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
# [UHF-9962](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9962)
Created sql-query which gets most relevant content recommendations for news_item nodes.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9962`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as admin
- Go and [enable the recommendations block](https://helfi-etusivu.docker.so/fi/admin/structure/block)
  - drush cr  
- View any news item which have annif-tags
  - [this one](https://helfi-etusivu.docker.so/fi/uutiset/kaupunginvaltuuston-kokouksessa-vuoden-2022-tilinpaatos-ja-arviointikertomus) has quite good recommendations.
- The page should load normally
- Under the original recommendations there should be new block
- Optional: Open one of the recommended news
  - Do cross referencing to see that the tags in both news have matches.

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations

* [ ] Translations have been added to .po -files and included in this PR


[UHF-9962]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ