### PR TITLE
UHF-X: Change Pinnalla juuri nyt to only say Pinnalla in Finnish

### DIFF
--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.current.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.current.yml
@@ -1,2 +1,2 @@
-label: 'Pinnalla juuri nyt (Vain etusivulle)'
+label: 'Pinnalla (Vain etusivulle)'
 description: 'Käytä AINOASTAAN etusivulla. Esittele ajankohtaisia aiheita linkkilistan muodossa.'

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -3,7 +3,7 @@ msgstr ""
 
 msgctxt "Current paragraph title"
 msgid "Trending"
-msgstr "Pinnalla juuri nyt"
+msgstr "Pinnalla"
 
 msgctxt "Front page top news paragraph title"
 msgid "Top stories"


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change `Pinnalla juuri nyt` to only say `Pinnalla` in Finnish.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_translation_change`
* Run `make drush-cim drush-cr drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the front page block `Pinnalla juuri nyt` has just `Pinnalla` as the title in Finnish. Check also that the paragraph is called `Pinnalla` in the editor interface as well.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR