### PR TITLE
UHF-10176 unify recommendations between translations

### DIFF
--- a/conf/cmi/field.field.node.news_item.field_annif_keywords.yml
+++ b/conf/cmi/field.field.node.news_item.field_annif_keywords.yml
@@ -13,7 +13,7 @@ bundle: news_item
 label: 'Annif keywords'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -18,8 +18,6 @@ use Drupal\helfi_annif\Client\KeywordClient;
  */
 final class KeywordManager {
 
-  const array SUPPORTED_LANGUAGES = ['fi'];
-
   /**
    * Taxonomy term storage.
    *
@@ -79,16 +77,6 @@ final class KeywordManager {
   }
 
   /**
-   * Check if entity language is in supported languages.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity.
-   */
-  private function isSupportedLanguage(EntityInterface $entity) : bool {
-    return in_array($entity->language()->getId(), self::SUPPORTED_LANGUAGES);
-  }
-
-  /**
    * Queues keyword generation for single entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -102,8 +90,6 @@ final class KeywordManager {
       $this->isEntityProcessed($entity) ||
       // Skip if entity does not support keywords.
       !$this->supportsKeywords($entity) ||
-      // Skip if entity's language is not supported.
-      !$this->isSupportedLanguage($entity) ||
       // Skip if entity already has keywords.
       (!$overwriteExisting && $this->hasKeywords($entity))
     ) {

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -18,7 +18,7 @@ use Drupal\helfi_annif\Client\KeywordClient;
  */
 final class KeywordManager {
 
-  CONST array SUPPORTED_LANGUAGES = ['fi'];
+  const array SUPPORTED_LANGUAGES = ['fi'];
 
   /**
    * Taxonomy term storage.
@@ -81,7 +81,7 @@ final class KeywordManager {
   /**
    * Check if entity language is in supported languages.
    *
-   * @param EntityInterface $entity
+   * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity.
    */
   private function isSupportedLanguage(EntityInterface $entity) : bool {
@@ -102,7 +102,7 @@ final class KeywordManager {
       $this->isEntityProcessed($entity) ||
       // Skip if entity does not support keywords.
       !$this->supportsKeywords($entity) ||
-      // Skip if entity's language is not supported
+      // Skip if entity's language is not supported.
       !$this->isSupportedLanguage($entity) ||
       // Skip if entity already has keywords.
       (!$overwriteExisting && $this->hasKeywords($entity))

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -18,6 +18,8 @@ use Drupal\helfi_annif\Client\KeywordClient;
  */
 final class KeywordManager {
 
+  CONST array SUPPORTED_LANGUAGES = ['fi'];
+
   /**
    * Taxonomy term storage.
    *
@@ -77,6 +79,16 @@ final class KeywordManager {
   }
 
   /**
+   * Check if entity language is in supported languages.
+   *
+   * @param EntityInterface $entity
+   *   The entity.
+   */
+  private function isSupportedLanguage(EntityInterface $entity) : bool {
+    return in_array($entity->language()->getId(), self::SUPPORTED_LANGUAGES);
+  }
+
+  /**
    * Queues keyword generation for single entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -90,6 +102,8 @@ final class KeywordManager {
       $this->isEntityProcessed($entity) ||
       // Skip if entity does not support keywords.
       !$this->supportsKeywords($entity) ||
+      // Skip if entity's language is not supported
+      !$this->isSupportedLanguage($entity) ||
       // Skip if entity already has keywords.
       (!$overwriteExisting && $this->hasKeywords($entity))
     ) {

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -71,7 +71,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       $recommendations = $this->recommendationManager
         ->getRecommendations($node, 3, 'fi');
     }
-    catch(\Exception $exception){
+    catch (\Exception $exception) {
       $this->logger->error($exception->getMessage());
     }
 

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -66,7 +66,15 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       '#title' => $this->t('You might be interested in'),
     ];
 
-    $recommendations = $this->recommendationManager->getRecommendations($node);
+    $recommendations = [];
+    try {
+      $recommendations = $this->recommendationManager
+        ->getRecommendations($node, 3, 'fi');
+    }
+    catch(\Exception $exception){
+      $this->logger->error($exception->getMessage());
+    }
+
     if (!$recommendations) {
       return $this->handleNoRecommendations($response);
     }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -45,8 +45,7 @@ class RecommendationManager {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = NULL): array {
-    $entity_langcode = $entity->language()->getId();
-    $target_langcode = $target_langcode ?? $entity_langcode;
+    $target_langcode = $target_langcode ?? $entity->language()->getId();
 
     $results = $this->executeQuery($entity, $target_langcode);
     if (!$results || !is_array($results)) {
@@ -65,7 +64,6 @@ class RecommendationManager {
     }
 
     $results = [];
-
     foreach ($entities as $entity) {
       if ($entity instanceof TranslatableInterface && $entity->hasTranslation($target_langcode)) {
         $results[] = $entity->getTranslation($target_langcode);

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_annif;
 
-use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -32,7 +30,7 @@ class RecommendationManager {
   /**
    * Get recommendations for a node.
    *
-   * @param EntityInterface $entity
+   * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The node.
    * @param int $limit
    *   How many recommendations should be be returned.
@@ -42,10 +40,10 @@ class RecommendationManager {
    * @return array
    *   Array of recommendations.
    *
-   * @throws InvalidPluginDefinitionException
-   * @throws PluginNotFoundException
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = null): array {
+  public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = NULL): array {
     $entity_langcode = $entity->language()->getId();
     $target_langcode = $target_langcode ?? $entity_langcode;
 
@@ -62,7 +60,7 @@ class RecommendationManager {
       ->loadMultiple($nids);
 
     $results = [];
-    foreach($entities as $entity) {
+    foreach ($entities as $entity) {
       if ($entity->hasTranslation($entity_langcode)) {
         $results[] = $entity->getTranslation($entity_langcode);
       }
@@ -80,7 +78,7 @@ class RecommendationManager {
    * The recommendations can be unified between the translations
    * by always getting the results using the primary language recommendations.
    *
-   * @param EntityInterface $entity
+   * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity we want to suggest recommendations for.
    * @param string $langcode
    *   Langcode which is used to filter results.

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -48,11 +48,10 @@ class RecommendationManager {
   public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = null): array {
     $entity_langcode = $entity->language()->getId();
     $target_langcode = $target_langcode ?? $entity_langcode;
-    $response = [];
 
     $results = $this->executeQuery($entity, $target_langcode);
     if (!$results || !is_array($results)) {
-      return $response;
+      return [];
     }
 
     $this->sortByCreatedAt($results);
@@ -67,7 +66,7 @@ class RecommendationManager {
       if ($entity->hasTranslation($entity_langcode)) {
         $results[] = $entity->getTranslation($entity_langcode);
       }
-      if (count($results) >= 3) {
+      if (count($results) >= $limit) {
         break;
       }
     }

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_annif;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\TranslatableInterface;
 
 /**
  * The recommendation manager.
@@ -64,8 +65,9 @@ class RecommendationManager {
     }
 
     $results = [];
+
     foreach ($entities as $entity) {
-      if ($entity->hasTranslation($target_langcode)) {
+      if ($entity instanceof TranslatableInterface && $entity->hasTranslation($target_langcode)) {
         $results[] = $entity->getTranslation($target_langcode);
       }
       if (count($results) >= $limit) {

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -112,7 +112,8 @@ class RecommendationManager {
       limit {$limit};
     ";
 
-    // Cannot add :limit as parameter here, must be added directly to the query string above.
+    // Cannot add :limit as parameter here,
+    // must be added directly to the query string above.
     return $this->connection
       ->query($query, [
         ':nid' => $entity->id(),
@@ -144,7 +145,7 @@ class RecommendationManager {
    * @param array $entities
    *   Array of entities sorted by id.
    * @param array $queryResult
-   *   Array of query results sorted correctly
+   *   Array of query results sorted correctly.
    *
    * @return array
    *   Correctly sorted array of entities.

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -34,9 +34,10 @@ class RecommendationManager {
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The node.
    * @param int $limit
-   *   How many recommendations should be be returned.
+   *   How many recommendations should be returned.
    * @param string|null $target_langcode
-   *   Which translation to use to select the recommendations, null meaning the entity's translation.
+   *   Which translation to use to select the recommendations,
+   *   null uses the entity's translation.
    *
    * @return array
    *   Array of recommendations.

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -36,7 +36,7 @@ class RecommendationManager {
    * @param int $limit
    *   How many recommendations should be be returned.
    * @param string|null $target_langcode
-   *   Allow sharing the recommendations between all translations.
+   *   Which translation to use to select the recommendations, null meaning the entity's translation.
    *
    * @return array
    *   Array of recommendations.
@@ -45,7 +45,8 @@ class RecommendationManager {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = NULL): array {
-    $target_langcode = $target_langcode ?? $entity->language()->getId();
+    $entity_langcode = $entity->language()->getId();
+    $target_langcode = $target_langcode ?? $entity_langcode;
 
     $results = $this->executeQuery($entity, $target_langcode);
     if (!$results || !is_array($results)) {
@@ -65,8 +66,8 @@ class RecommendationManager {
 
     $results = [];
     foreach ($entities as $entity) {
-      if ($entity instanceof TranslatableInterface && $entity->hasTranslation($target_langcode)) {
-        $results[] = $entity->getTranslation($target_langcode);
+      if ($entity instanceof TranslatableInterface && $entity->hasTranslation($entity_langcode)) {
+        $results[] = $entity->getTranslation($entity_langcode);
       }
       if (count($results) >= $limit) {
         break;

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -48,6 +48,9 @@ class RecommendationManager {
   public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = NULL): array {
     $destination_langcode = $entity->language()->getId();
     $target_langcode = $target_langcode ?? $destination_langcode;
+    if (!$entity->hasTranslation($target_langcode)) {
+      $target_langcode = $destination_langcode;
+    }
 
     $queryResult = $this->executeQuery($entity, $target_langcode, $destination_langcode, $limit);
     if (!$queryResult || !is_array($queryResult)) {

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -59,10 +59,14 @@ class RecommendationManager {
       ->getStorage($entity->getEntityTypeId())
       ->loadMultiple($nids);
 
+    if (!$entity->getEntityType()->isTranslatable()) {
+      return array_splice($entities, 0, 3);
+    }
+
     $results = [];
     foreach ($entities as $entity) {
-      if ($entity->hasTranslation($entity_langcode)) {
-        $results[] = $entity->getTranslation($entity_langcode);
+      if ($entity->hasTranslation($target_langcode)) {
+        $results[] = $entity->getTranslation($target_langcode);
       }
       if (count($results) >= $limit) {
         break;

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -48,7 +48,7 @@ class RecommendationManager {
   public function getRecommendations(EntityInterface $entity, int $limit = 3, string $target_langcode = NULL): array {
     $destination_langcode = $entity->language()->getId();
     $target_langcode = $target_langcode ?? $destination_langcode;
-    if (!$entity->hasTranslation($target_langcode)) {
+    if ($entity instanceof TranslatableInterface && !$entity->hasTranslation($target_langcode)) {
       $target_langcode = $destination_langcode;
     }
 


### PR DESCRIPTION
# [UHF-10176](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10176)
Allow showing same recommendations for all translations if possible


## What was done
Using target_langcode allows showing the main language's recommendations for all translations if possible.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10176`
  * `make fresh`
* Run `make drush-cr`

## How to test

[The Original testing instructions apply](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/626).
- Check that the english and swedish news has the same recommendations if possible

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-10176]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ