### PR TITLE
UHF-9493: Drupal 10.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,9 +74,6 @@
     },
     "extra": {
         "patches": {
-            "drupal/core": {
-                "[#3272985] Rss feed cached response content-type header fix": "https://www.drupal.org/files/issues/2022-04-07/drupal-3272985-views-rss-feed-response-content-type--MR2063-at-f49f4274--20220407.patch"
-            },
             "drupal/draggableviews": {
                 "Save langcode as part of draggableviews data in order to sort by by weight and language": "patches/draggableviews_language.patch"
             }


### PR DESCRIPTION
# [UHF-9493](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed fixed patch for [#3272985] Rss feed cached response content-type header as it is fixed in Drupal 10.3.

## How to install

* Run the following commands on your etusivu instance
  * `git checkout dev`
  * `make fresh`
  * `git checkout UHF-9493`
  * `composer require drupal/helfi_platform_config:dev-UHF-9493 drupal/helfi_proxy:dev-UHF-9493 -W`
     * If none of the patches actually gets installed, you can run `rm -rf public/core && composer i` to make sure the patches gets installed correctly.
  * `make drush-cr drush-deploy` 

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the RSS feed cached response works
   * Make sure you don't have any caches set to `cache.backend.null`
   * Go to https://helfi-etusivu.docker.so/fi/uutiset/rss, open network tab and load the page twice. 
   * Make sure the response type is `Content-Type: application/rss+xml;`
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/252
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/780
* https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/pull/73
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/653

[UHF-9493]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ