### PR TITLE
UHF-10048 annif-keyword cache tag invalidation

### DIFF
--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -272,7 +272,7 @@ final class KeywordManager {
     // processedItems is set for update hooks.
     $this->processedItems[$this->getEntityKey($entity)] = TRUE;
 
-    $this->invalidateKeywordTermsCacheTags($terms);
+    $this->invalidateCacheTags($terms);
     $entity->save();
   }
 
@@ -326,7 +326,7 @@ final class KeywordManager {
    * @param array $terms
    *   Array of terms to process.
    */
-  private function invalidateKeywordTermsCacheTags(array $terms): void {
+  private function invalidateCacheTags(array $terms): void {
     $cacheTags = array_map(
       fn ($term) => $term->getCacheTags(),
       $terms

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -45,7 +45,7 @@ final class KeywordManager {
    *   The keyword generator.
    * @param \Drupal\Core\Queue\QueueFactory $queueFactory
    *   The queue factory.
-   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cacheTagsInvalidator
    *   The cache validator.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException

--- a/public/modules/custom/helfi_annif/src/KeywordManager.php
+++ b/public/modules/custom/helfi_annif/src/KeywordManager.php
@@ -45,6 +45,8 @@ final class KeywordManager {
    *   The keyword generator.
    * @param \Drupal\Core\Queue\QueueFactory $queueFactory
    *   The queue factory.
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   *   The cache validator.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_annif\Plugin\Block;
 
-use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
@@ -138,7 +136,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       $entity->get('field_annif_keywords')->referencedEntities()
     );
 
-    // flatten array by merging the destructed arrays.
+    // Flatten array by merging the destructed arrays.
     return array_merge(...$cacheTags);
   }
 

--- a/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
+++ b/public/modules/custom/helfi_annif/src/Plugin/Block/RecommendationsBlock.php
@@ -133,10 +133,13 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       return [];
     }
 
-    return array_map(
-      fn ($item) => "taxonomy_term:{$item['target_id']}",
-      $entity->get('field_annif_keywords')->getValue()
+    $cacheTags = array_map(
+      fn ($term) => $term->getCacheTags(),
+      $entity->get('field_annif_keywords')->referencedEntities()
     );
+
+    // flatten array by merging the destructed arrays.
+    return array_merge(...$cacheTags);
   }
 
 }

--- a/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
@@ -25,6 +25,7 @@ class KeywordManagerTest extends KernelTestBase {
 
   use AnnifApiTestTrait;
 
+
   /**
    * {@inheritdoc}
    */
@@ -35,7 +36,6 @@ class KeywordManagerTest extends KernelTestBase {
     'taxonomy',
     'language',
     'helfi_annif',
-    'cache_tags.invalidator',
   ];
 
   /**

--- a/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
@@ -133,10 +133,13 @@ class KeywordManagerTest extends KernelTestBase {
       ->get(Argument::any())
       ->willReturn($queue);
 
+    $cacheInvalidator = $this->container->get('cache_tags.invalidator');
+    
     return new KeywordManager(
       $entityTypeManager,
       $client,
-      $queueFactory->reveal()
+      $queueFactory->reveal(),
+      $cacheInvalidator
     );
   }
 

--- a/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
@@ -134,7 +134,7 @@ class KeywordManagerTest extends KernelTestBase {
       ->willReturn($queue);
 
     $cacheInvalidator = $this->container->get('cache_tags.invalidator');
-    
+
     return new KeywordManager(
       $entityTypeManager,
       $client,

--- a/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Kernel/KeywordManagerTest.php
@@ -35,6 +35,7 @@ class KeywordManagerTest extends KernelTestBase {
     'taxonomy',
     'language',
     'helfi_annif',
+    'cache_tags.invalidator',
   ];
 
   /**

--- a/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_annif\Unit\TextConverter;
 
-use Drupal\Core\Cache\CacheTagsInvalidator;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;

--- a/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
@@ -133,7 +133,8 @@ class KeywordManagerTest extends UnitTestCase {
     return new KeywordManager(
       $entityTypeManager->reveal(),
       $client,
-      $queueFactory->reveal()
+      $queueFactory->reveal(),
+      $cacheInvalidator
     );
   }
 

--- a/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
@@ -128,6 +128,8 @@ class KeywordManagerTest extends UnitTestCase {
       ->get(Argument::any())
       ->willReturn($queue);
 
+    $cacheInvalidator = $this->container->get('cache_tags.invalidator');
+
     return new KeywordManager(
       $entityTypeManager->reveal(),
       $client,

--- a/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
+++ b/public/modules/custom/helfi_annif/tests/src/Unit/KeywordManagerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_annif\Unit\TextConverter;
 
+use Drupal\Core\Cache\CacheTagsInvalidator;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
@@ -128,13 +130,15 @@ class KeywordManagerTest extends UnitTestCase {
       ->get(Argument::any())
       ->willReturn($queue);
 
-    $cacheInvalidator = $this->container->get('cache_tags.invalidator');
+    $cacheInvalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $cacheInvalidator
+      ->invalidateTags(['taxonomy_term:1234']);
 
     return new KeywordManager(
       $entityTypeManager->reveal(),
       $client,
       $queueFactory->reveal(),
-      $cacheInvalidator
+      $cacheInvalidator->reveal(),
     );
   }
 


### PR DESCRIPTION
# [UHF-10048](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10048)
Update recommendations for old news when processing a set of keywords for new or existing news item.

## What was done
Added cache tags for annif recommendations block.
Added cache invalidation when processing Annif-keyword request.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10048`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Make sure your cache is working properly (no local.settings changes etc.)
- Make sure you have the annif-block enabled.
- Go to any news item page as incognito user
- Open inspector and network tab and refresh the page
- Check the response headers cache tags
  - You should see some of the Annif-keyword term ids mentioned in the response headers cache tags
    - For example `taxonomy_term:1870`

Cache invalidation:
- Edit existing news item and save it
- Figure out the best way to check which cache tags are invalidated
  - For example, `xdebug` 
  - OR edit the code, add `var_dump(array_merge(...$cacheTags));` or something at the `end of invalidateKeywordTermsCacheTags -function in KeywordManager.php`
- Edit one of the news and run `drush cron` to trigger the keyword update
  - (the drush command won't update existing keywords if not mistaken) 
 
You should see the an array of taxonomy_term:{term_id} to be invalidated.


[UHF-10048]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ