### PR TITLE
UHF-10067: Add permissions for news producer to edit image and remote videos

### DIFF
--- a/conf/cmi/user.role.news_producer.yml
+++ b/conf/cmi/user.role.news_producer.yml
@@ -5,9 +5,6 @@ dependencies:
   config:
     - filter.format.full_html
     - filter.format.minimal
-    - media.type.file
-    - media.type.hel_map
-    - media.type.helfi_chart
     - media.type.image
     - media.type.remote_video
     - node.type.news_article
@@ -38,9 +35,6 @@ permissions:
   - 'administer nodes'
   - 'cancel account'
   - 'change own username'
-  - 'create file media'
-  - 'create hel_map media'
-  - 'create helfi_chart media'
   - 'create image media'
   - 'create media'
   - 'create news_article content'
@@ -48,24 +42,22 @@ permissions:
   - 'create paragraph library item'
   - 'create remote_video media'
   - 'create url aliases'
+  - 'delete any image media'
   - 'delete any news_article content'
   - 'delete any news_item content'
+  - 'delete any remote_video media'
   - 'delete media'
   - 'delete news_article revisions'
   - 'delete news_item revisions'
-  - 'delete own file media'
   - 'delete own files'
-  - 'delete own hel_map media'
-  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own news_article content'
   - 'delete own news_item content'
   - 'delete own remote_video media'
+  - 'edit any image media'
   - 'edit any news_article content'
   - 'edit any news_item content'
-  - 'edit own file media'
-  - 'edit own hel_map media'
-  - 'edit own helfi_chart media'
+  - 'edit any remote_video media'
   - 'edit own image media'
   - 'edit own news_article content'
   - 'edit own news_item content'


### PR DESCRIPTION
# [UHF-10067](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10067)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add permissions for news producer to edit image and remote videos
* Remove permissions to files, maps and charts because the role can not create this type of content

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10067`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Log in as uid 1 and add yourself super-admin role so that you are able to create users.
* [x] Add new user with news_producer role
* [x] Log in with said user and make sure you are now able to edit images are remote video media added by other people but you are also still able to add them yourself too.
* [x] Make sure you are no longer able to add file, map or chart type media (since news don't contain any of this type of media there is no reason for news_producer role to have these permissions)
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-10067]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ