### PR TITLE
UHF-9658: Add documentation about the custom roles on front page instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ editable title and description.
 `hdbt_subtheme_preprocess_paragraph` [here](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/blob/dev/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme)
 - Fallback view when JavaScript is not enabled can be found in the `/conf/cim` folder [here](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/blob/dev/conf/cmi/views.view.news_archive_index.yml).
 
+### Custom roles
+
+#### Menu API (menu_api)
+
+Role used for writing the global menu entities through the API.
+
+#### News producer (news_producer)
+
+User role limited to news item and article production.
+
 ### Global navigation
 
 Global navigation refers to the common navigation elements that can be found on all the core instances. This instance


### PR DESCRIPTION
# [UHF-9658](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9658)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated documentation about instance specific roles.

## How to install

* No installation required

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Read the README, check if the information is accurate and if there is something that it is missing.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

[UHF-9658]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ