### PR TITLE
UHF-10364: Stop top articles block from dropping old content away 

### DIFF
--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -234,7 +234,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 4
+          items_per_page: 3
       exposed_form:
         type: basic
         options:
@@ -1400,6 +1400,11 @@ display:
           text: view
           output_url_as_text: true
           absolute: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 4
       sorts:
         weight:
           id: weight
@@ -1431,6 +1436,7 @@ display:
           view_mode: medium_teaser
       defaults:
         title: false
+        pager: false
         style: false
         row: false
         fields: false

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -80,31 +80,6 @@ function helfi_etusivu_views_query_alter(ViewExecutable $view, QueryPluginBase $
 }
 
 /**
- * Implements hook_cron().
- */
-function helfi_etusivu_cron() : void {
-  // Get promoted news_item nodes that are more than one month old.
-  $result = \Drupal::entityQuery('node')
-    ->condition('type', ['news_item', 'news_article'], 'IN')
-    ->condition('promote', 1)
-    ->condition('created', strtotime('-1 month'), '<')
-    ->range(0, 50)
-    ->accessCheck(FALSE)
-    ->execute();
-
-  $promoted_nodes = \Drupal::entityTypeManager()
-    ->getStorage('node')
-    ->loadMultiple($result);
-
-  // Remove promotion.
-  foreach ($promoted_nodes as $node) {
-    $node->setPromoted(FALSE);
-    $node->save();
-  }
-
-}
-
-/**
  * Implements hook_helfi_paragraph_types().
  */
 function helfi_etusivu_helfi_paragraph_types() : array {


### PR DESCRIPTION
# [UHF-10364](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10364)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove the cron code that removes old news and articles from the top news block
* Change the top news block with articles to list only 3 articles as it should

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10364`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure that news items and articles that were created more than one month ago, still stay promoted on the top news block even if you run cron.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation