### PR TITLE
UHF-9964: Remove the link to automatic categories taxonomy terms that are displayed on the news item and article pages

### DIFF
--- a/conf/cmi/core.entity_form_display.node.news_article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.news_article.default.yml
@@ -110,7 +110,7 @@ content:
         entity_reference_entity_view:
           view_mode: default
         entity_reference_label:
-          link: true
+          link: false
       show_description: false
     third_party_settings: {  }
   created:

--- a/conf/cmi/core.entity_form_display.node.news_item.default.yml
+++ b/conf/cmi/core.entity_form_display.node.news_item.default.yml
@@ -125,7 +125,7 @@ content:
         entity_reference_entity_view:
           view_mode: default
         entity_reference_label:
-          link: true
+          link: false
       show_description: false
     third_party_settings: {  }
   created:

--- a/public/modules/custom/helfi_etusivu_config/config/rewrite/core.entity_form_display.node.news_item.default.yml
+++ b/public/modules/custom/helfi_etusivu_config/config/rewrite/core.entity_form_display.node.news_item.default.yml
@@ -102,7 +102,7 @@ content:
         entity_reference_entity_view:
           view_mode: default
         entity_reference_label:
-          link: true
+          link: false
       show_description: false
     third_party_settings: {  }
 hidden:

--- a/public/modules/custom/helfi_node_news_article/config/install/core.entity_form_display.node.news_article.default.yml
+++ b/public/modules/custom/helfi_node_news_article/config/install/core.entity_form_display.node.news_article.default.yml
@@ -25,6 +25,7 @@ dependencies:
     - path
     - publication_date
     - radioactivity
+    - readonly_field_widget
     - scheduler
     - select2
 third_party_settings:
@@ -75,11 +76,41 @@ third_party_settings:
         open: false
         description: ''
         required_fields: true
+    group_automatically_recommended:
+      children:
+        - in_recommendations
+        - show_annif_block
+        - annif_keywords
+      label: 'Automatically recommended content'
+      region: content
+      parent_name: ''
+      weight: 25
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Recommended content may include news or articles. Recommendations are based on automatically selected news categories. The news categories are chosen based on the page content when the page is saved.'
+        required_fields: false
 id: node.news_article.default
 targetEntityType: node
 bundle: news_article
 mode: default
 content:
+  annif_keywords:
+    type: readonly_field_widget
+    weight: 30
+    region: content
+    settings:
+      label: above
+      formatter_type: entity_reference_label
+      formatter_settings:
+        entity_reference_entity_view:
+          view_mode: default
+        entity_reference_label:
+          link: false
+      show_description: false
+    third_party_settings: {  }
   created:
     type: datetime_timestamp
     weight: 4
@@ -196,6 +227,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  in_recommendations:
+    type: boolean_checkbox
+    weight: 28
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -232,6 +270,13 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  show_annif_block:
+    type: boolean_checkbox
+    weight: 29
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   simple_sitemap:
     weight: 12


### PR DESCRIPTION
# [UHF-9964](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9964)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This fixes issue with visible html on the annif terms on news item and article edit pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9964_bugfix`
  * `make fresh`
* Run `make drush-cr drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to check that news items that have automatic news category terms on the edit page are no longer links and that there is no visible html-code.
* [ ] Do the same check to news articles.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-9964]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ