### PR TITLE
UHF-10469: Add news articles to rss feed and fallback listing of news archive

### DIFF
--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.field_lead_in
     - field.storage.node.field_main_image
+    - node.type.news_article
     - node.type.news_item
     - taxonomy.vocabulary.news_group
     - taxonomy.vocabulary.news_neighbourhoods
@@ -437,15 +438,45 @@ display:
           id: type
           table: node_field_data
           field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          operator: in
           value:
+            news_article: news_article
             news_item: news_item
           group: 1
+          exposed: false
           expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         langcode:
           id: langcode
           table: node_field_data
@@ -1080,15 +1111,45 @@ display:
           id: type
           table: node_field_data
           field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          operator: in
           value:
+            news_article: news_article
             news_item: news_item
           group: 1
+          exposed: false
           expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         langcode:
           id: langcode
           table: node_field_data


### PR DESCRIPTION
# [UHF-10469](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10469)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added news articles to rss feed and fallback view of news archive.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10469_news_articles_to_rss`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that news archive fallback and rss feed now lists news articles as well. If you are using the latest database from testing you should have for example on the topic "Kansainvälinen Helsinki"  a news article as the latest article in that topic called `Helsinki yllättää tapahtumakaupunkina – lyhyessäkin ajassa ehtii monenlaista`. Before this change it was not listed on the fallback view or the rss feed - only on the React application: https://helfi-etusivu.docker.so/fi/uutiset?topic[0]=500&page=1
* [x] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-10469]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ