### PR TITLE
UHF-10296: enable new recommendations block, restrict old one to other languages

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_aipoweredrecommendations.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_aipoweredrecommendations.yml
@@ -1,6 +1,6 @@
 uuid: 6ab1786a-6f04-44a4-afe2-b7c9829fd000
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_annif

--- a/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
@@ -1,10 +1,11 @@
 uuid: 2780cd50-1615-40f6-a1eb-7a193bad7c9a
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - views.view.frontpage_news
   module:
+    - language
     - node
     - views
   theme:
@@ -32,3 +33,20 @@ visibility:
     bundles:
       news_article: news_article
       news_item: news_item
+  language:
+    id: language
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_interface'
+    langcodes:
+      de: de
+      fr: fr
+      ru: ru
+      uk: uk
+      ar: ar
+      et: et
+      fa: fa
+      es: es
+      so: so
+      se: se
+      zh-hans: zh-hans

--- a/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_views_block__frontpage_news_of_interest.yml
@@ -1,6 +1,6 @@
 uuid: 2780cd50-1615-40f6-a1eb-7a193bad7c9a
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.frontpage_news

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -111,7 +111,7 @@ class RecommendationManager {
       and nfd.status = 1
       and n.langcode = :target_langcode
       and annif.langcode = :target_langcode
-      and nfd.langcode = :target_langcode
+      and nfd.langcode = :destination_langcode
       and n.nid != :nid
       and nfd.created > :timestamp
       group by n.nid

--- a/public/modules/custom/helfi_annif/src/RecommendationManager.php
+++ b/public/modules/custom/helfi_annif/src/RecommendationManager.php
@@ -110,7 +110,7 @@ class RecommendationManager {
            where restriction.in_recommendations_value = 0)
       and nfd.status = 1
       and n.langcode = :target_langcode
-      and annif.langcode = :destination_langcode
+      and annif.langcode = :target_langcode
       and nfd.langcode = :target_langcode
       and n.nid != :nid
       and nfd.created > :timestamp


### PR DESCRIPTION
# [UHF-10296](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10296)
Enable new AI powered recommendations

## What was done
Set old news recommendations block enabled for other languages
Enabled new news recommendations block for main languages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10296`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as admin
  - Go check block layout
  - `Frontpage news: Of interest` should be enabled for languages other than FI,EN,SV
  - `AI powered recommendations` should be enabled for FI,EN,SV
- Go to check any news item: check check main languages
  - Recommendations block should be visible
- Go to fronpage with other language, for example /uk
  - Go check news item, you should still see the old recommendations block 
recommendations

* [x] Check that this feature works



[UHF-10296]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ