### PR TITLE
UHF-10485: alter didn't trigger for articles because of wrong view id

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ menu and block fallbacks for the alternative languages. See more from the module
 
 ### News and article feed reordering with drupal/draggableviews
 
-Drupal/draggableviews -module is used to allow content creators to reorder the ´main news feed´ and ´main articles feed´
+Drupal/draggableviews -module is used to allow content creators to reorder the `main news feed` and `main articles feed`
 located in the front page. Adding content to the front page news feed can be done from node edit page by enabling
-`Näytä artikkeli pääartikkelivirrassa` selection.
+`Publish the news article in the top news articles flow` selection.
 
 Draggableviews-module doesn't support translations out of the box and some patching has been done to get it working.
 The initial feed ordering view was done in [this PR](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/103/files#diff-eac9bb841152af0a402bf0d14621ac75c98ff734db71f6a34a7156b9812346df)
-- langcode -column added to draggableviews -database table.
-- Query alter for views utilizing draggableviews to filter out content by language.
-- Page preprocess to add custom styles to the ordering views.
+- `langcode` column was added to draggableviews -database table.
+- Query alter was created for views utilizing draggableviews to filter out content by language.
+- Page preprocess was included to add custom styling to the admin interface of the view used to organize the items.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,15 @@ each paragraph that support the alternative languages. For example `paragraphs.p
 
 Regarding this alternative language support there is a custom module called `helfi_alt_lang_fallback` that provides
 menu and block fallbacks for the alternative languages. See more from the module itself [here](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/tree/dev/public/modules/custom/helfi_alt_lang_fallback).
+
+### News and article feed reordering with drupal/draggableviews
+
+Drupal/draggableviews -module is used to allow content creators to reorder the ´main news feed´ and ´main articles feed´
+located in the front page. Adding content to the front page news feed can be done from node edit page by enabling
+`Näytä artikkeli pääartikkelivirrassa` selection.
+
+Draggableviews-module doesn't support translations out of the box and some patching has been done to get it working.
+The initial feed ordering view was done in [this PR](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/103/files#diff-eac9bb841152af0a402bf0d14621ac75c98ff734db71f6a34a7156b9812346df)
+- langcode -column added to draggableviews -database table.
+- Query alter for views utilizing draggableviews to filter out content by language.
+- Page preprocess to add custom styles to the ordering views.

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -62,7 +62,7 @@ function helfi_etusivu_form_node_form_alter(&$form, FormStateInterface $form_sta
 function helfi_etusivu_views_query_alter(ViewExecutable $view, QueryPluginBase $query) : void {
   $draggable_views = [
     'frontpage_news',
-    'ordered_news_articles',
+    'ordered_news_articles_list',
     'ordered_news_list',
   ];
   if (in_array($view->id(), $draggable_views)) {


### PR DESCRIPTION
# [UHF-10485](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10485)

Article feed reordering view didn't filter the translations and caused duplicates in the view.


## What was done
Fixed the view id from query alter.
Updated site specific documentation with a mention about draggableviews module.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10485`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Go edit different articles' translations and add them to front page feed.
- Go reorder the feed with different languages
- Go to frontpage and check out the feed in different languages
The feed should have correct articles in it

Read the documentation changes

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10485]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ