### PR TITLE
UHF-10452: Change the front page latest news blocks news archive base url again

### DIFF
--- a/conf/cmi/language/fi/views.view.frontpage_news.yml
+++ b/conf/cmi/language/fi/views.view.frontpage_news.yml
@@ -9,11 +9,11 @@ display:
     display_options:
       title: 'Uusimmat uutiset'
       use_more_text: 'Katso kaikki uutiset'
-      link_url: /uutiset/arkisto
+      link_url: /uutiset/etsi-uutisia
     display_title: 'Uusimmat uutiset'
   latest_news_minimal:
     display_options:
       title: 'Uusimmat uutiset'
       use_more_text: 'Katso kaikki uutiset'
-      link_url: /uutiset/arkisto
+      link_url: /uutiset/etsi-uutisia
     display_title: 'Uusimmat uutiset'

--- a/conf/cmi/language/sv/views.view.frontpage_news.yml
+++ b/conf/cmi/language/sv/views.view.frontpage_news.yml
@@ -9,9 +9,9 @@ display:
     display_options:
       title: 'Senaste nyheter'
       use_more_text: 'Se alla nyheter'
-      link_url: /nyheter/arkiv
+      link_url: /nyheter/sok-efter-nyheter
   latest_news_minimal:
     display_options:
       title: 'Senaste nyheter'
       use_more_text: 'Se alla nyheter'
-      link_url: /nyheter/arkiv
+      link_url: /nyheter/sok-efter-nyheter

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -631,7 +631,7 @@ display:
       use_more_always: true
       use_more_text: 'See all news'
       link_display: custom_url
-      link_url: /news/archive
+      link_url: /news/search-for-news
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -797,7 +797,7 @@ display:
       use_more_always: true
       use_more_text: 'See all news'
       link_display: custom_url
-      link_url: /news/archive
+      link_url: /news/search-for-news
       display_extenders: {  }
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
# NOTICE!
When this PR is merged and deployed to testing the following changes need to be made manually to front page instance:
* Change the current news archive url to `/news/search-for-news` / `/uutiset/etsi-uutisia` / `/nyheter/sok-efter-nyheter` 
* Create a new landing page called `Current` and have it on the `/news` / `/uutiset` / `/nyheter` path.

# [UHF-10452](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10452)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the front page latest news blocks news archive base url to point to `/news/search-for-news`

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10452`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the front page latest news paragraphs "see all news" link in English leads to `/news/search-for-news` url. Remember to check with both minimal and card design.
* [ ] Check that the front page latest news paragraphs "see all news" link in English leads to `/uutiset/etsi-uutisia` url. Remember to check with both minimal and card design.
* [ ] Check that the front page latest news paragraphs "see all news" link in English leads to `/nyheter/sok-efter-nyheter` url. Remember to check with both minimal and card design.
* [ ] Remember to check the [helfi_platform_config PR](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/795) as well.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to the required files and included in this PR.

## Other PRs
<!-- For example an related PR in another repository -->
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/799
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/695

[UHF-10452]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ