### PR TITLE
UHF-10452: Change the latest news card and minimal layouts to have different links and texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ selected color palette of the node that the paragraph is added to.
 
 #### Latest news (front_page_latest_news)
 
-_Latest news_ paragraph lists six latest news and links to the news archive page. You can select between two designs
-for the listing (minimal and cards). The link for the news archive page is hardcoded, and it is done in the view called
-`frontpage_news`. The configuration is found from `views.view.frontpage_news.yml` and the link to news archive page is
-defined [here](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/blob/e2643195b8fc2989da835313c052ae533b8e0143/conf/cmi/views.view.frontpage_news.yml#L594).
+_Latest news_ paragraph lists six latest news and links to the news archive page or the "What's new" page. You can
+select between two designs for the listing (minimal and cards). The links for the news archive page / "What's new" page
+are hardcoded, and it is done in the view called `frontpage_news`. The minimal design links to the "What's new" page and
+the card design links to the news archive page. The configuration is found from `views.view.frontpage_news.yml` and
+the links are defined there for each display.
 
 #### News update (news_update)
 

--- a/conf/cmi/language/fi/views.view.frontpage_news.yml
+++ b/conf/cmi/language/fi/views.view.frontpage_news.yml
@@ -8,12 +8,12 @@ display:
   latest_news_cards:
     display_options:
       title: 'Uusimmat uutiset'
-      use_more_text: 'Katso kaikki uutiset'
+      use_more_text: 'Etsi uutisia'
       link_url: /uutiset/etsi-uutisia
     display_title: 'Uusimmat uutiset'
   latest_news_minimal:
     display_options:
       title: 'Uusimmat uutiset'
-      use_more_text: 'Katso kaikki uutiset'
-      link_url: /uutiset/etsi-uutisia
+      use_more_text: 'Katso kaikki ajankohtaiset'
+      link_url: /uutiset
     display_title: 'Uusimmat uutiset'

--- a/conf/cmi/language/sv/views.view.frontpage_news.yml
+++ b/conf/cmi/language/sv/views.view.frontpage_news.yml
@@ -8,10 +8,10 @@ display:
   latest_news_cards:
     display_options:
       title: 'Senaste nyheter'
-      use_more_text: 'Se alla nyheter'
+      use_more_text: 'Sök efter nyheter'
       link_url: /nyheter/sok-efter-nyheter
   latest_news_minimal:
     display_options:
       title: 'Senaste nyheter'
-      use_more_text: 'Se alla nyheter'
-      link_url: /nyheter/sok-efter-nyheter
+      use_more_text: 'Se alla aktuella'
+      link_url: /nyheter

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -629,7 +629,7 @@ display:
       display_description: ''
       use_more: true
       use_more_always: true
-      use_more_text: 'See all news'
+      use_more_text: 'Search for news'
       link_display: custom_url
       link_url: /news/search-for-news
       display_extenders: {  }
@@ -795,9 +795,9 @@ display:
       display_description: ''
       use_more: true
       use_more_always: true
-      use_more_text: 'See all news'
+      use_more_text: "See what's new"
       link_display: custom_url
-      link_url: /news/search-for-news
+      link_url: /news
       display_extenders: {  }
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
# [UHF-10452](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10452)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change the latest news card and minimal layouts to have different links and texts since they are used on different parts of the site.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10452_latest_news_link_modification`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that minimal version of latest news paragraph links to "/news" url and cards version of the same paragraph links to "/news/search-for-news" and that the links in question have different texts: "Search for news" for the cards version and "See what's new" for the minimal version.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR


[UHF-10452]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ