### PR TITLE
UHF-10554: Prefer english when content does not have translation

### DIFF
--- a/conf/cmi/language.entity.en.yml
+++ b/conf/cmi/language.entity.en.yml
@@ -7,5 +7,5 @@ _core:
 id: en
 label: English
 direction: ltr
-weight: -8
+weight: -11
 locked: false


### PR DESCRIPTION
# [UHF-10554](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10554)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Prefer english when content does not have translation to current language.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10554`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create an announcement in finnish, then add english translation.
* [ ] Go to [/uk](https://helfi-etusivu.docker.so/uk), the english announcement should be rendered.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/807


[UHF-10554]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ