### PR TITLE
UHF-10724: Add the image author information for article hero

### DIFF
--- a/public/modules/custom/helfi_node_news_article/helfi_node_news_article.module
+++ b/public/modules/custom/helfi_node_news_article/helfi_node_news_article.module
@@ -162,6 +162,7 @@ function helfi_node_news_article_theme() : array {
         'title' => NULL,
         'description' => NULL,
         'image' => NULL,
+        'image_author' => NULL,
         'published_time' => NULL,
         'html_published_time' => NULL,
         'updated_time' => NULL,

--- a/public/modules/custom/helfi_node_news_article/src/Plugin/Block/NewsArticleHeroBlock.php
+++ b/public/modules/custom/helfi_node_news_article/src/Plugin/Block/NewsArticleHeroBlock.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\helfi_node_news_article\Plugin\Block;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\Exception\MissingDataException;
 use Drupal\helfi_node_news_article\Entity\Node\NewsArticle;
 use Drupal\helfi_platform_config\Plugin\Block\ContentBlockBase;
 
@@ -69,12 +71,28 @@ class NewsArticleHeroBlock extends ContentBlockBase {
       ?->first()
       ?->view($image_display_options);
 
+    $image_author = '';
+
+    $image_author_name =  $media
+      ?->get('field_photographer')
+      ?->first()
+      ?->getString();
+
+    if(!empty($image_author_name)) {
+      $image_author = t(
+        'Image: @image_author',
+        ['@image_author' => $image_author_name],
+        ['context' => 'Helfi Paragraphs Hero']
+      );
+    }
+
     $build['news_article_hero_block'] = [
       '#theme' => 'news_article_hero_block',
       '#title' => $entity->label(),
       '#description' => $entity->get('field_lead_in')?->first()?->view(),
       '#design' => $entity->get('field_hero_design')?->first()?->getString(),
       '#image' => $image,
+      '#image_author' => $image_author,
       '#published_time' => $entity->getPublishedHumanReadable(),
       '#html_published_time' => $entity->getPublishedMachineReadable(),
       '#updated_time' => $entity->getUpdatedHumanReadable(),

--- a/public/modules/custom/helfi_node_news_article/templates/news-article-hero-block.html.twig
+++ b/public/modules/custom/helfi_node_news_article/templates/news-article-hero-block.html.twig
@@ -22,6 +22,7 @@
   title: title,
   description: lead_in,
   image: image,
+  image_author: image_author,
   published_time: published_time,
   html_published_time: html_published_time,
   updated_time: updated_time,


### PR DESCRIPTION
# [UHF-10724](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10724)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add the image author information so that it is visible on news_article hero.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10724`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any news_article content and make sure that the hero image on the page has the photographer information visible if the information is provided on the photo. If not there shouldn't be anything under the hero image and it should work still fine.
* [ ] Check that the translations work as well.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR