### PR TITLE
UHF-11176: Add addresslabel param to kartta.hel.fi links

### DIFF
--- a/public/modules/custom/helfi_etusivu/src/Enum/ServiceMapLink.php
+++ b/public/modules/custom/helfi_etusivu/src/Enum/ServiceMapLink.php
@@ -21,10 +21,10 @@ enum ServiceMapLink {
    */
   public function link(): string {
     return match($this) {
-      ServiceMapLink::ROADWORK_EVENTS => 'eCBuut',
-      ServiceMapLink::CITYBIKE_STATIONS_STANDS => 'eCAduu',
-      ServiceMapLink::STREET_PARK_PROJECTS => 'eCBJGT',
-      ServiceMapLink::PLANS_IN_PROCESS => 'eCCv3K',
+      ServiceMapLink::ROADWORK_EVENTS => 'eDAB7W',
+      ServiceMapLink::CITYBIKE_STATIONS_STANDS => 'eDFeCc',
+      ServiceMapLink::STREET_PARK_PROJECTS => 'eDBTcc',
+      ServiceMapLink::PLANS_IN_PROCESS => 'eDB7Rk',
     };
   }
 

--- a/public/modules/custom/helfi_etusivu/src/Servicemap.php
+++ b/public/modules/custom/helfi_etusivu/src/Servicemap.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_etusivu;
 
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\helfi_etusivu\Enum\ServiceMapLink;
@@ -18,6 +19,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * Class for interacting with Servicemap API.
  */
 final class Servicemap {
+
+  use StringTranslationTrait;
 
   /**
    * API URL for querying data.
@@ -32,7 +35,6 @@ final class Servicemap {
    */
   private const SITE_URL = 'https://kartta.hel.fi/';
 
-
   /**
    * Gets the address label for a given service map link.
    *
@@ -44,13 +46,12 @@ final class Servicemap {
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup
    *   The address label corresponding to the service map link.
    */
-
   private function getAddressLabel(ServiceMapLink $link, string $address) : TranslatableMarkup {
     return match($link) {
-      ServiceMapLink::ROADWORK_EVENTS => t('Street works and events near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
-      ServiceMapLink::CITYBIKE_STATIONS_STANDS => t('City bike stations and bicycle racks near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
-      ServiceMapLink::STREET_PARK_PROJECTS => t('Street and park projects near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
-      ServiceMapLink::PLANS_IN_PROCESS => t('Plans under preparation near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::ROADWORK_EVENTS => $this->t('Street works and events near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::CITYBIKE_STATIONS_STANDS => $this->t('City bike stations and bicycle racks near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::STREET_PARK_PROJECTS => $this->t('Street and park projects near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::PLANS_IN_PROCESS => $this->t('Plans under preparation near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
     };
   }
 

--- a/public/modules/custom/helfi_etusivu/src/Servicemap.php
+++ b/public/modules/custom/helfi_etusivu/src/Servicemap.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_etusivu;
 
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\helfi_etusivu\Enum\ServiceMapLink;
 use GuzzleHttp\ClientInterface;
@@ -30,6 +31,28 @@ final class Servicemap {
    * @var string
    */
   private const SITE_URL = 'https://kartta.hel.fi/';
+
+
+  /**
+   * Gets the address label for a given service map link.
+   *
+   * @param \Drupal\helfi_etusivu\Enum\ServiceMapLink $link
+   *   The service map link option.
+   * @param string $address
+   *   The address for which the label is generated.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The address label corresponding to the service map link.
+   */
+
+  private function getAddressLabel(ServiceMapLink $link, string $address) : TranslatableMarkup {
+    return match($link) {
+      ServiceMapLink::ROADWORK_EVENTS => t('Street works and events near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::CITYBIKE_STATIONS_STANDS => t('City bike stations and bicycle racks near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::STREET_PARK_PROJECTS => t('Street and park projects near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+      ServiceMapLink::PLANS_IN_PROCESS => t('Plans under preparation near the address @address', ['@address' => $address], ['context' => 'Helsinki near you address label']),
+    };
+  }
 
   /**
    * Constructs a new instance.
@@ -104,8 +127,9 @@ final class Servicemap {
   public function getLink(ServiceMapLink $link, string $address) : string {
     $langcode = $this->languageManager->getCurrentLanguage()->getId();
     $query = [
-      'link' => $link->link(),
+      'addresslabel' => $this->getAddressLabel($link, $address),
       'addresslocation' => Xss::filter($address),
+      'link' => $link->link(),
       'setlanguage' => $langcode,
     ];
 

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -199,4 +199,4 @@ msgstr "Katu- ja puistohankkeet lähellä osoitetta @address"
 
 msgctxt "Helsinki near you address label"
 msgid "Plans under preparation near the address @address"
-msgstr "Valmisteilla oleva kaavat lähellä osoitetta @address"
+msgstr "Valmisteilla olevat kaavat lähellä osoitetta @address"

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -155,7 +155,7 @@ msgstr "Katu- ja puistohankkeet kartalla"
 
 msgctxt "Helsinki near you"
 msgid "Plans in process on map"
-msgstr "Valmisteilla oleva kaavat kartalla"
+msgstr "Valmisteilla olevat kaavat kartalla"
 
 msgctxt "Helsinki near you"
 msgid "Please enter an address"
@@ -184,3 +184,19 @@ msgstr "Yksi osoite-ehdotus löytyi."
 msgctxt "Helsinki near you form"
 msgid "@selectedItem @position of @count is highlighted"
 msgstr "Vaihtoehto numero @position: @selectedItem korostettu. Vaihtoehtojen määrä: @count."
+
+msgctxt "Helsinki near you address label"
+msgid "Street works and events near the address @address"
+msgstr "Katutyöt ja tapahtumat lähellä osoitetta @address"
+
+msgctxt "Helsinki near you address label"
+msgid "City bike stations and bicycle racks near the address @address"
+msgstr "Kaupunkipyöräasemat ja pyörätelineet lähellä osoitetta @address"
+
+msgctxt "Helsinki near you address label"
+msgid "Street and park projects near the address @address"
+msgstr "Katu- ja puistohankkeet lähellä osoitetta @address"
+
+msgctxt "Helsinki near you address label"
+msgid "Plans under preparation near the address @address"
+msgstr "Valmisteilla oleva kaavat lähellä osoitetta @address"

--- a/public/modules/custom/helfi_etusivu/translations/sv.po
+++ b/public/modules/custom/helfi_etusivu/translations/sv.po
@@ -173,3 +173,19 @@ msgstr "Det finns ett resultat tillgängligt."
 msgctxt "Helsinki near you form"
 msgid "@selectedItem @position of @count is highlighted"
 msgstr "@selectedItem @position av @count är markerad"
+
+msgctxt "Helsinki near you address label"
+msgid "Street works and events near the address @address"
+msgstr "Gatuarbeten och evenemang nära adressen @address"
+
+msgctxt "Helsinki near you address label"
+msgid "City bike stations and bicycle racks near the address @address"
+msgstr "Stadscykelstationer och cykelställ nära adressen @address"
+
+msgctxt "Helsinki near you address label"
+msgid "Street and park projects near the address @address"
+msgstr "Gatu- och parkprojekt nära adressen @address"
+
+msgctxt "Helsinki near you address label"
+msgid "Plans under preparation near the address @address"
+msgstr "Detaljplaner under beredning nära adressen @address"


### PR DESCRIPTION
# [UHF-11176](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11176)

Add adresslabel param to links to provide better info to user.

## What was done

* Add addresslabel param to external links in Helsinki near you services block
* Add translations
* Fix existing typo in translations
* Fix kartta.hel.fi link hashes (old ones contained pin of a random address)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout origin/11176`
  * `make fresh`
* Run `make drush-cr`

## How to test

* Go to Helsinki near you results page, eg. https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tulokset?q=Heteniityntie%2B4
* Follow the external links (ending in "... on map") to kartta.hel.fi
* Check that the displayed shows data you'd expect to see (map loading might take a long time)
* You should see a blue pin in the middle of the map. On the right bottom corner, in the "On the map now" infobox, you should see label for the pin corresponding to the addresslabel query param passed in the url. Disclaimer: The map seems to inconsistently load the with the pin in the middle. A reload usually works.
* Check that code is up to our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR



[UHF-11176]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ