### PR TITLE
UHF-11151: alter published time

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -354,7 +354,7 @@ function helfi_etusivu_theme() : array {
  * UHF-11151 For updating news items, set the published time
  * same as the changed time for better google search results.
  */
-function helfi_etusivu_metatags_alter(array &$metatags, array &$context) {
+function helfi_etusivu_metatags_alter(array &$metatags, array &$context): void {
   $entity = $context['entity'];
   if (!$entity instanceof NewsItem) {
     return;

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -350,6 +350,9 @@ function helfi_etusivu_theme() : array {
 
 /**
  * Implements hook_metatags_alter().
+ *
+ * UHF-11151 For updating news items, set the published time
+ * same as the changed time for better google search results.
  */
 function helfi_etusivu_metatags_alter(array &$metatags, array &$context) {
   $entity = $context['entity'];

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -347,3 +347,17 @@ function helfi_etusivu_theme() : array {
     ],
   ];
 }
+
+/**
+ * Implements hook_metatags_alter().
+ */
+function helfi_etusivu_metatags_alter(array &$metatags, array &$context) {
+  $entity = $context['entity'];
+  if (!$entity instanceof NewsItem) {
+    return;
+  }
+
+  if (!$entity->get('field_news_item_updating_news')->isEmpty()) {
+    $metatags['article_published_time'] = '[node:changed:html_datetime]';
+  }
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -361,6 +361,6 @@ function helfi_etusivu_metatags_alter(array &$metatags, array &$context) {
   }
 
   if (!$entity->get('field_news_item_updating_news')->isEmpty()) {
-    $metatags['article_published_time'] = '[node:changed:html_datetime]';
+    $metatags['article_published_time'] = '[updating-news:changed:html_datetime]';
   }
 }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Contains token data for helfi_etusivu.
+ */
+
+declare(strict_types=1);
+
+use Drupal\helfi_etusivu\Entity\Node\NewsItem;
+
+/**
+ * Implements hook_token_info().
+ */
+function helfi_etusivu_token_info(): array {
+  $info = [];
+
+  $info['types']['node']['updating-news:changed:html_datetime'] = [
+    'name' => 'updating-news',
+    'description' => 'Get the latest changed time of updating news',
+    'needs-data' => 'node'
+  ];
+
+  $info['tokens']['node']['updating-news:changed:html_datetime'] = [
+    'name' => 'Updating news latest update',
+  ];
+
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function helfi_etusivu_tokens(
+  $type,
+  $tokens,
+  array $data,
+): array {
+  if ($type !== 'updating-news' || empty($data['node'])) {
+    return [];
+  }
+  $replacements = [];
+  $entity = $data['node'];
+
+  foreach ($tokens as $original) {
+    if (
+      !$entity instanceof NewsItem ||
+      $original !== '[updating-news:changed:html_datetime]'
+    ) {
+      continue;
+    }
+
+    $updates = $entity->getNewsUpdates();
+    $latest = end($updates);
+    // @phpstan-ignore-next-line
+    $datetime = $latest->get('field_news_update_date')
+      ->date
+      ->setTimezone(new DateTimeZone('Europe/Helsinki'))
+      ->format('c');
+
+    $replacements[$original] = $datetime;
+  }
+
+  return $replacements;
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
@@ -24,7 +24,7 @@ function helfi_etusivu_token_info(): array {
   $info['tokens']['node']['updating-news:changed:html_datetime'] = [
     'name' => 'Updating news latest update',
   ];
-  
+
   return $info;
 }
 

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
@@ -61,7 +61,7 @@ function helfi_etusivu_tokens(
       ->date
       ->getTimestamp();
 
-    $datetime = $dateFormatterService->format($timestamp,'html_datetime', 'c');
+    $datetime = $dateFormatterService->format($timestamp, 'html_datetime', 'c');
 
     $replacements[$original] = $datetime;
   }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
@@ -39,6 +39,10 @@ function helfi_etusivu_tokens(
   if ($type !== 'updating-news' || empty($data['node'])) {
     return [];
   }
+
+  /** @var \Drupal\Core\Datetime\DateFormatterInterface $dateFormatterService */
+  $dateFormatterService = \Drupal::service('date.formatter');
+
   $replacements = [];
   $entity = $data['node'];
 
@@ -53,10 +57,11 @@ function helfi_etusivu_tokens(
     $updates = $entity->getNewsUpdates();
     $latest = end($updates);
     // @phpstan-ignore-next-line
-    $datetime = $latest->get('field_news_update_date')
+    $timestamp = $latest->get('field_news_update_date')
       ->date
-      ->setTimezone(new DateTimeZone('Europe/Helsinki'))
-      ->format('c');
+      ->getTimestamp();
+
+    $datetime = $dateFormatterService->format($timestamp,'html_datetime', 'c');
 
     $replacements[$original] = $datetime;
   }

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.tokens.inc
@@ -18,14 +18,13 @@ function helfi_etusivu_token_info(): array {
   $info['types']['node']['updating-news:changed:html_datetime'] = [
     'name' => 'updating-news',
     'description' => 'Get the latest changed time of updating news',
-    'needs-data' => 'node'
+    'needs-data' => 'node',
   ];
 
   $info['tokens']['node']['updating-news:changed:html_datetime'] = [
     'name' => 'Updating news latest update',
   ];
-
-
+  
   return $info;
 }
 

--- a/public/modules/custom/helfi_etusivu/src/Entity/Node/NewsItem.php
+++ b/public/modules/custom/helfi_etusivu/src/Entity/Node/NewsItem.php
@@ -48,7 +48,7 @@ final class NewsItem extends RecommendableBase {
    * @return \Drupal\Core\Entity\EntityInterface[]
    *   News updates entities.
    */
-  private function getNewsUpdates() : array {
+  public function getNewsUpdates() : array {
     $field = $this->get('field_news_item_updating_news');
     assert($field instanceof EntityReferenceFieldItemListInterface);
     return $field->referencedEntities();

--- a/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
+++ b/tests/dtt/src/ExistingSite/NewsContentTypeTest.php
@@ -123,7 +123,7 @@ class NewsContentTypeTest extends ExistingSiteTestBase {
   }
 
   /**
-   * Tests that adding news update sets published_at field.
+   * Tests that adding news update sets published_at field and the article:published_time metatag updates.
    */
   public function testNewsUpdate() : void {
     $node = $this->createNode([
@@ -152,6 +152,13 @@ class NewsContentTypeTest extends ExistingSiteTestBase {
 
     // Adding news update should have updated published_at field.
     $this->assertEquals($node->get('published_at')->value, $updateTime->getTimestamp());
+
+    $dateFormatter = $this->container->get('date.formatter');
+    $newTimestamp = $dateFormatter->format($update->get('field_news_update_date')->date->getTimestamp(), 'html_datetime', 'c');
+
+    // Article:published_time-metatag is set to the updated news creation time.
+    $this->drupalGet($node->toUrl());
+    $this->assertSession()->elementAttributeContains('css', 'meta[property="article:published_time"]', 'content', $newTimestamp);
   }
 
   /**


### PR DESCRIPTION
# [UHF-11151](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11151)
Better google results by altering article_published_time -metatag on updating news

## What was done
Added metatag_alter which sets the article_published_time from `published time` to `changed time`

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11151`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Go and see an [existing updating news](https://helfi-etusivu.docker.so/fi/uutiset/lahes-100-000-helsinkilaista-otti-korona-ja-influenssarokotuksen-syksyn-aikana-rokotukset-jatkuvat) or create a new one with one or more updates.
- Go see the updating news and check the metatags
  - Metatag `article:published_time`'s date should match the creation date of the latest news-update
- Check any news item without any updates and edit it just in case: The published time should be different than changed time


[UHF-11151]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ