### PR TITLE
UHF-11495: Top news block empty content fix

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-top-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-top-news.html.twig
@@ -24,10 +24,10 @@
         use_component_title_lang_fallback: alternative_language ?? false,
         component_content_class: component_content_class
       }
-      %}
-        {% block component_content %}
-          {{ drupal_view('frontpage_news', view)  }}
-        {% endblock component_content %}
+    %}
+      {% block component_content %}
+        {{ drupal_view('frontpage_news', view) }}
+      {% endblock component_content %}
     {% endembed %}
   {% endblock paragraph %}
 

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-top-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-top-news.html.twig
@@ -14,17 +14,21 @@
   {% set view = 'main_news' %}
 {% endif %}
 
-{% block paragraph %}
-  {% embed "@hdbt/misc/component.twig" with
-    {
-      component_classes: component_classes,
-      component_title: component_title,
-      use_component_title_lang_fallback: alternative_language ?? false,
-      component_content_class: component_content_class
-    }
-    %}
-      {% block component_content %}
-        {{ drupal_view('frontpage_news', view) }}
-      {% endblock component_content %}
-  {% endembed %}
-{% endblock paragraph %}
+{% if drupal_view_result('frontpage_news', view) is not empty %}
+
+  {% block paragraph %}
+    {% embed "@hdbt/misc/component.twig" with
+      {
+        component_classes: component_classes,
+        component_title: component_title,
+        use_component_title_lang_fallback: alternative_language ?? false,
+        component_content_class: component_content_class
+      }
+      %}
+        {% block component_content %}
+          {{ drupal_view('frontpage_news', view)  }}
+        {% endblock component_content %}
+    {% endembed %}
+  {% endblock paragraph %}
+
+{% endif %}


### PR DESCRIPTION
# [UHF-11495](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11495)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add check around the top news content block to make sure that the content is not empty.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11495`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Log in and go to front page. Make sure you can see the "Top stories" block and the "Learn more" block.
* [ ] Open https://helfi-etusivu.docker.so/en/admin/ordered-news and https://helfi-etusivu.docker.so/en/admin/ordered-news-articles to new tabs.
* [x] From either one, remove all the articles/news. This means that you have to edit each added node and uncheck the "Näytä uutinen pääuutisvirrassa/Näytä artikkeli pääartikkelivirrassa" option and save the node.
* [x] Now go to front page and there shouldn't be any trace of the block visible anymore. Before the title would show still even if there was no content.
* [x] Test the other block as well and test one language version as well.
* [x] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-11495]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ