### PR TITLE
UHF-11654: Publication date metatag

### DIFF
--- a/conf/cmi/metatag.metatag_defaults.node__news_article.yml
+++ b/conf/cmi/metatag.metatag_defaults.node__news_article.yml
@@ -1,11 +1,8 @@
-uuid: 9a7ba25b-3012-4457-aa5b-99fe3c0d87cb
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: SK-c5yVwCPoF2ik9ncEi-CRQDj0JrwIfabMS-u9uDGc
-id: node__news_item
-label: 'Content: News item'
+id: node__news_article
+label: 'Content: News article'
 tags:
   article_published_time: '[node:published:html_datetime]'
   title: '[node:short-title] | [site:page-title-suffix]'


### PR DESCRIPTION
# [UHF-11654](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11654)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the news item and news article "Article publication date & time" metatags to be created from `[node:published:html_datetime]` token instead of the node creation time.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11654`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Change any news item or news article published date time and check that the `article:published_time` metatag gets updated correctly. 
   * `<meta property="article:published_time" content="[the actual published date]">`
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
