### PR TITLE
UHF-10647: Temporary elasticsearch settings for recommendations block

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -5,6 +5,17 @@
  * Contains site specific overrides.
  */
 
+// Elasticsearch server config for suggestions server.
+if (getenv('ELASTICSEARCH_URL')) {
+  $config['search_api.server.etusivu']['backend_config']['connector_config']['url'] = getenv('ELASTICSEARCH_URL');
+
+  if (getenv('ELASTIC_USER') && getenv('ELASTIC_PASSWORD')) {
+    $config['search_api.server.etusivu']['backend_config']['connector'] = 'helfi_connector';
+    $config['search_api.server.etusivu']['backend_config']['connector_config']['username'] = getenv('ELASTIC_USER');
+    $config['search_api.server.etusivu']['backend_config']['connector_config']['password'] = getenv('ELASTIC_PASSWORD');
+  }
+}
+
 // Elastic proxy URL.
 $config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_URL');
 


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

Search API can't reach the elasticsearch server used for suggestion topics indexing in any environment other than local development. 

## What was done

We don't yet have a shared routing for all core instances, so let's use the endpoint configuration from the default server for now to allow recommendations to function properly on etusivu.

## How to test

This needs to be tested in test environment after merging.

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/952


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ