### PR TITLE
UHF-10647: Removing site specific configuration for etusivu elasticsearch

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -5,17 +5,6 @@
  * Contains site specific overrides.
  */
 
-// Elasticsearch server config for suggestions server.
-if (getenv('ELASTICSEARCH_URL')) {
-  $config['search_api.server.etusivu']['backend_config']['connector_config']['url'] = getenv('ELASTICSEARCH_URL');
-
-  if (getenv('ELASTIC_USER') && getenv('ELASTIC_PASSWORD')) {
-    $config['search_api.server.etusivu']['backend_config']['connector'] = 'helfi_connector';
-    $config['search_api.server.etusivu']['backend_config']['connector_config']['username'] = getenv('ELASTIC_USER');
-    $config['search_api.server.etusivu']['backend_config']['connector_config']['password'] = getenv('ELASTIC_PASSWORD');
-  }
-}
-
 // Elastic proxy URL.
 $config['elastic_proxy.settings']['elastic_proxy_url'] = getenv('ELASTIC_PROXY_URL');
 


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

## What was done

Removing a site specific config override for etusivu elasticsearch server in favor of using the shared override from `drupal-helfi-platform`.

## How to test

Not really sure if this is something we can test in local? We might just need to test this in the test environment once this and https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/321 have been merged.

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/321


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ