### PR TITLE
UHF-9754: Add LinkedEvents service

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
@@ -10,3 +10,4 @@ services:
     tags:
       - { name: helfi_platform_config.og_image_builder }
   Drupal\helfi_etusivu\Servicemap: ~
+  Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents: ~

--- a/public/modules/custom/helfi_etusivu/src/Controller/HelsinkiNearYouEventsController.php
+++ b/public/modules/custom/helfi_etusivu/src/Controller/HelsinkiNearYouEventsController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\helfi_etusivu\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\helfi_react_search\LinkedEvents;
+use Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents;
 
 /**
  * Events near you landing page controller.
@@ -37,7 +37,7 @@ class HelsinkiNearYouEventsController extends ControllerBase {
                 'field_event_time' => TRUE,
                 'field_free_events' => TRUE,
                 'field_remote_events' => TRUE,
-                'places' => $this->linkedEvents->getPlacesList($events_url),
+                'places' => [],
                 'hideHeading' => TRUE,
                 'useFullLocationFilter' => TRUE,
                 'useFullTopicsFilter' => TRUE,

--- a/public/modules/custom/helfi_etusivu/src/Controller/HelsinkiNearYouResultsController.php
+++ b/public/modules/custom/helfi_etusivu/src/Controller/HelsinkiNearYouResultsController.php
@@ -12,7 +12,7 @@ use Drupal\helfi_etusivu\Enum\InternalSearchLink;
 use Drupal\helfi_etusivu\Enum\ServiceMapLink;
 use Drupal\helfi_etusivu\ServiceMapInterface;
 use Drupal\helfi_paragraphs_news_list\Entity\ExternalEntity\Term;
-use Drupal\helfi_react_search\LinkedEvents;
+use Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -28,7 +28,7 @@ class HelsinkiNearYouResultsController extends ControllerBase {
    *
    * @param \Drupal\helfi_etusivu\ServiceMapInterface $servicemap
    *   The servicemap service.
-   * @param \Drupal\helfi_react_search\LinkedEvents $linkedEvents
+   * @param \Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents $linkedEvents
    *   The linked events service.
    */
   public function __construct(

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_etusivu\HelsinkiNearYou;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Url;
+
+/**
+ * Linked events helper.
+ */
+class LinkedEvents {
+
+  public const BASE_URL = 'https://tapahtumat.hel.fi';
+  protected const API_URL = 'https://api.hel.fi/linkedevents/v1/';
+
+  public function __construct(private readonly LanguageManagerInterface $languageManager) {}
+
+  /**
+   * Form url for getting events from api.
+   *
+   * @param array $options
+   *   Filters as key = value array.
+   * @param string $pageSize
+   *   How many events to load in a page.
+   *
+   * @return string
+   *   Resulting api url with params a query string
+   */
+  public function getEventsRequest(array $options = [], string $pageSize = '3') : string {
+    $defaultOptions = [
+      'event_type' => 'General',
+      'format' => 'json',
+      'include' => 'keywords,location',
+      'page' => 1,
+      'page_size' => $pageSize,
+      'sort' => 'end_time',
+      'start' => 'now',
+      'super_event_type' => 'umbrella,none',
+      'language' => $this->languageManager
+        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getId(),
+    ];
+
+    $options = array_merge($defaultOptions, $options);
+
+    if (!isset($options['all_ongoing_AND'])) {
+      $options['all_ongoing'] = 'true';
+    }
+
+    // Linked events URLs should end with '/' (URLs without '/' are redirect).
+    return Url::fromUri(self::API_URL . 'event/', options: ['query' => $options])->toString();
+  }
+
+}

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/Controller/HelsinkiNearYouResultsControllerTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/Controller/HelsinkiNearYouResultsControllerTest.php
@@ -13,7 +13,7 @@ use Drupal\external_entities\Entity\Query\External\Query;
 use Drupal\helfi_etusivu\Controller\HelsinkiNearYouResultsController;
 use Drupal\helfi_etusivu\Servicemap;
 use Drupal\helfi_etusivu\ServiceMapInterface;
-use Drupal\helfi_react_search\LinkedEvents;
+use Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents;
 use Drupal\KernelTests\KernelTestBase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\InputBag;

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEventsTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEventsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_etusivu\Kernel\HelsinkiNearYou;
+
+use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\helfi_etusivu\HelsinkiNearYou\LinkedEvents;
+use Drupal\KernelTests\KernelTestBase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Tests linked events helper service.
+ */
+class LinkedEventsTest extends KernelTestBase {
+
+  use ProphecyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'helfi_etusivu',
+  ];
+
+  /**
+   * Tests getEventsRequest method.
+   */
+  public function testEventsRequest(): void {
+    $language = new Language(['id' => 'en']);
+
+    $languageManager = $this->prophesize(LanguageManagerInterface::class);
+    $languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->willReturn($language);
+
+    $linkedEvents = new LinkedEvents($languageManager->reveal());
+    $url = $linkedEvents->getEventsRequest();
+
+    $this->assertEquals('https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=3&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=en&all_ongoing=true', $url);
+  }
+
+}


### PR DESCRIPTION
# [UHF-9754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

LinkedEvents service was reworked in UHF-9754, but etusivu still relied on the previous implementation. This patch brings the features that etusivu needs to this repo.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9754-fix-helsinki-near-you`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that [helsinki-near-you](https://helfi-etusivu.docker.so/fi/helsinki-lahellasi) shows events.
* [x] Check that [event](https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tapahtumat?address=Mannerheimintie%2030) page works.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-9754]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ