### PR TITLE
UHF-12029: LinkitWidget

### DIFF
--- a/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldWidget/HelfiLinkitWidget.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/Field/FieldWidget/HelfiLinkitWidget.php
@@ -6,7 +6,6 @@ namespace Drupal\helfi_etusivu\Plugin\Field\FieldWidget;
 
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Field\Attribute\FieldWidget;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\linkit\Plugin\Field\FieldWidget\LinkitWidget;
@@ -26,47 +25,19 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class HelfiLinkitWidget extends LinkitWidget {
 
   /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected RequestStack $requestStack;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $plugin_id,
-      $plugin_definition,
-      $configuration['field_definition'],
-      $configuration['settings'],
-      $configuration['third_party_settings'],
-      $container->get('request_stack'),
-    );
-  }
-
-  /**
-   * Constructs a new instance.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The widget settings.
-   * @param array $third_party_settings
-   *   The widget third party settings.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-   *   The current request stack.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  public function __construct(
-    $plugin_id,
-    $plugin_definition,
-    FieldDefinitionInterface $field_definition,
-    array $settings,
-    array $third_party_settings,
-    protected RequestStack $requestStack,
-  ) {
-    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
   }
 
   /**


### PR DESCRIPTION
# [UHF-12029](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12029)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed helfi linkit widget problem: Call to a member function hasPermission() on null

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12029`
  * `make fresh`
* Run `make drush-cr`
* Verify that drupal core is updated to ^10.5 `composer info drupal/core | head`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to edit this page: https://helfi-etusivu.docker.so/fi/node/7402/edit
   * [ ] This error should be gone: 
   ```
   Error: Call to a member function hasPermission() on null in Drupal\linkit\Plugin\Field\FieldWidget\LinkitWidget->formElement() (line 134 of modules/contrib/linkit/src/Plugin/Field/FieldWidget/LinkitWidget.php).

   ```
* [ ] Check that code follows our standards

