### PR TITLE
UHF-12100: Hiding "Roadwork near you" and "Feedback near you" from anonymous users

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -420,7 +420,6 @@ function helfi_etusivu_theme() : array {
         'service_groups' => NULL,
         'nearby_neighbourhoods' => NULL,
         'news_archive_url' => NULL,
-        'roadwork_section' => NULL,
         'feedback_section' => NULL,
         'feedback_archive_url' => NULL,
       ],

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
@@ -36,6 +36,7 @@ helfi_etusivu.helsinki_near_you_roadworks:
     _title_callback: '\Drupal\helfi_etusivu\HelsinkiNearYou\Controller\RoadworksController::getTitle'
   requirements:
     _permission: 'access content'
+    _role: 'authenticated'
 
 helfi_etusivu.helsinki_near_you_feedbacks:
   path: '/helsinki-near-you/feedback'
@@ -44,6 +45,7 @@ helfi_etusivu.helsinki_near_you_feedbacks:
     _title_callback: '\Drupal\helfi_etusivu\HelsinkiNearYou\Controller\FeedbacksController::getTitle'
   requirements:
     _permission: 'access content'
+    _role: 'authenticated'
 
 helfi_etusivu.helsinki_near_you_roadworks_api:
   path: '/api/helsinki-near-you/roadworks'

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
@@ -100,8 +100,6 @@ class ResultsController extends ControllerBase {
     // Array format: [longitude, latitude] per GeoJSON specification.
     [$lon, $lat] = $addressData['coordinates'];
 
-    $roadworkSection = $this->buildRoadworkSection($request, $lat, $lon, $address);
-
     $build = [
     // Set the theme for the results page.
       '#theme' => 'helsinki_near_you_results_page',
@@ -156,10 +154,8 @@ class ResultsController extends ControllerBase {
       ),
       '#nearby_neighbourhoods' => $neighborhoods,
       '#service_groups' => $this->buildServiceGroups($addressName),
-      // Include roadwork section in the build array.
-      '#roadwork_section' => $roadworkSection,
       '#cache' => [
-        'contexts' => ['url.query_args:q'],
+        'contexts' => ['url.query_args:q', 'user.roles:anonymous'],
         'tags' => ['roadwork_section'],
       ],
       '#feedback_archive_url' => Url::fromRoute('helfi_etusivu.helsinki_near_you_feedbacks', options: [

--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
@@ -110,55 +110,61 @@
     {% endif %}
 
     {# React Roadwork Section #}
-    {% embed "@hdbt/misc/component.twig" with
-      {
-        component_classes: [
-        'component--react-search',
-        'component--roadworks',
-        'component--coordinates-based-list',
-        ],
-        component_title: 'Street and park projects near you'|trans({}, {'context': 'Helsinki near you'}),
-        component_description: 'Browse street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
-        component_content_class: 'roadwork-list',
-      }
-    %}
-      {% block component_content %}
-        {{ attach_library('hdbt/roadwork-list') }}
-        <div
-          id="helfi-roadworks-search"
-          data-paragraph-id="helfi-coordinates-based-roadwork-list"
-        >
-        </div>
-        {# Indicate JS not enabled #}
-        <noscript>
-          <div class="roadwork-list__javascript-disabled">
-            {{ 'You must enable JavaScript in your browser to view the street and park project list.'|t({}, {'context': 'Helsinki near you'}) }}
+    {# #UHF-12100: Hide from anonymous users temporarily as its not ready for the public yet. #}
+    {% if logged_in %}
+      {% embed "@hdbt/misc/component.twig" with
+        {
+          component_classes: [
+          'component--react-search',
+          'component--roadworks',
+          'component--coordinates-based-list',
+          ],
+          component_title: 'Street and park projects near you'|trans({}, {'context': 'Helsinki near you'}),
+          component_description: 'Browse street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
+          component_content_class: 'roadwork-list',
+        }
+      %}
+        {% block component_content %}
+          {{ attach_library('hdbt/roadwork-list') }}
+          <div
+            id="helfi-roadworks-search"
+            data-paragraph-id="helfi-coordinates-based-roadwork-list"
+          >
           </div>
-        </noscript>
-      {% endblock component_content %}
-    {% endembed %}
+          {# Indicate JS not enabled #}
+          <noscript>
+            <div class="roadwork-list__javascript-disabled">
+              {{ 'You must enable JavaScript in your browser to view the street and park project list.'|t({}, {'context': 'Helsinki near you'}) }}
+            </div>
+          </noscript>
+        {% endblock component_content %}
+      {% endembed %}
+    {% endif %}
 
-    {% embed "@hdbt/misc/component.twig" with
-      {
-        component_classes: [ 'component--feedback' ],
-        component_title: 'Feedback near you'|trans({}, {'context': 'Feedback close to you block'}),
-        component_description: 'Browse feedback near you.'|trans({}, {'context': 'Feedback close to you block'}),
-        component_content_class: 'feedback',
-      }
-    %}
-      {% block component_content %}
-      {{ feedback_section }}
+    {# #UHF-12100: Hide from anonymous users temporarily as its not ready for the public yet. #}
+    {% if logged_in %}
+      {% embed "@hdbt/misc/component.twig" with
+        {
+          component_classes: [ 'component--feedback' ],
+          component_title: 'Feedback near you'|trans({}, {'context': 'Feedback close to you block'}),
+          component_description: 'Browse feedback near you.'|trans({}, {'context': 'Feedback close to you block'}),
+          component_content_class: 'feedback',
+        }
+      %}
+        {% block component_content %}
+        {{ feedback_section }}
 
-        <div class="see-all-button see-all-button--feedback-results">
-          {% set feedback_archive_title = 'See all feedback near you'|t({}, {'context': 'Feedback close to you block'}) %}
-          {% include '@hdbt/navigation/link-button.html.twig' with {
-            type: 'primary',
-            label: feedback_archive_title,
-            url: feedback_archive_url,
-          } %}
-        </div>
-      {% endblock component_content %}
-    {% endembed %}
+          <div class="see-all-button see-all-button--feedback-results">
+            {% set feedback_archive_title = 'See all feedback near you'|t({}, {'context': 'Feedback close to you block'}) %}
+            {% include '@hdbt/navigation/link-button.html.twig' with {
+              type: 'primary',
+              label: feedback_archive_title,
+              url: feedback_archive_url,
+            } %}
+          </div>
+        {% endblock component_content %}
+      {% endembed %}
+    {% endif %}
 
     {% include '@hdbt_subtheme/module/helfi-etusivu/helsinki-near-you-feedback-block.html.twig' %}
   </div>


### PR DESCRIPTION
# [UHF-12100](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12100)

"Roadwork near you" and "Feedback near you" sections in "Helsinki near you" results are not yet ready for the public.

## What was done

* Added a role condition to show "Roadwork near you" and "Feedback near you" sections in "Helsinki near you" results to logged in users only.
* Added a role restriction to "Roadwork near you" and "Feedback near you" routes to allow access to logged in users only.

## How to install

* Make sure your etusivu instance is up and running on correct branch.
  * `git checkout UHF-12100`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check that "Roadwork near you" and "Feedback near you" sections and routes are only accessible when logged in
  * [ ] While logged out go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi, then make a search with any address --> You should not see result sections "Roadwork near you" or "Feedback near you"
  * [ ] While logged out go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tietyot --> You should get an "Access denied" error page
  * [ ] While logged out go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/palautteet --> You should get an "Access denied" error page
  * [ ] While logged in go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi, then make a search with any address --> You should now see result sections "Roadwork near you" or "Feedback near you"
  * [ ] While logged in go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tietyot --> You should be able to search and get results for an address
  * [ ] While logged in go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/palautteet --> You should be able to search and get results for an address
* [ ] Check that code follows our standards
