### PR TITLE
UHF-10321: Restrict menu_api role to private networks only

### DIFF
--- a/public/sites/default/all.services.yml
+++ b/public/sites/default/all.services.yml
@@ -1,0 +1,3 @@
+parameters:
+  helfi_api_base.restricted_roles:
+    - 'menu_api'


### PR DESCRIPTION
# [UHF-10321](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10321)
<!-- What problem does this solve? -->

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/220
