### PR TITLE
UHF-X: Fix wrong translation in Helsinki near you section

### DIFF
--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -139,7 +139,7 @@ msgstr "Aurausaikataulu"
 
 msgctxt "Helsinki near you"
 msgid "Roadworks on the map"
-msgstr "Katu- ja puistohankkeet kartalla"
+msgstr "Katutyöt kartalla"
 
 msgctxt "Helsinki near you"
 msgid "City bike stations and bikeracks on the map"


### PR DESCRIPTION
# UHF-X: Fix wrong translation in Helsinki near you section
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed wrong translation in Helsinki near you section

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch && git checkout UHF-X_fix_translation_in_helsinki_near_you`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the translation for the link is now correct in results page (for example https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tulokset?q=Pasilankatu%2B2) The left box link should say "Katutyöt kartalla" instead of "Katu- ja puistohankkeet kartalla".
* [x] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR