### PR TITLE
UHF-X: Hiding roadwork near me from anonymous users

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
@@ -40,6 +40,7 @@ helfi_etusivu.helsinki_near_you_roadworks:
     _big_pipe_force_placeholders: 'TRUE'
   requirements:
     _permission: 'access content'
+    _role: 'authenticated'
 
 helfi_etusivu.helsinki_near_you_feedbacks:
   path: '/helsinki-near-you/feedback'

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
@@ -105,7 +105,7 @@ final class ResultsController extends ControllerBase {
       '#roadwork_archive_url' => $this->roadworkDataService->getSeeAllUrl($address, $langcode),
       '#roadwork_section' => $this->buildRoadworks($address, $langcode, 3, new Attribute(['class' => ['card--border']])),
       '#cache' => [
-        'contexts' => ['url.query_args:q'],
+        'contexts' => ['url.query_args:q', 'user.roles:authenticated'],
         'tags' => ['roadwork_section'],
       ],
       '#feedback_archive_url' => Url::fromRoute('helfi_etusivu.helsinki_near_you_feedbacks', options: [

--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
@@ -107,29 +107,31 @@
     {% endif %}
 
     {# Roadwork Section #}
-    {% embed "@hdbt/misc/component.twig" with
-      {
-        component_classes: [
-        'component--roadworks',
-        'component--coordinates-based-list',
-        ],
-        component_title: 'Street and park projects near you'|trans({}, {'context': 'Helsinki near you'}),
-        component_description: 'Browse street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
-        component_content_class: 'roadwork-list',
-      }
-    %}
-      {% block component_content %}
-        {{ roadwork_section }}
+    {% if logged_in %}
+      {% embed "@hdbt/misc/component.twig" with
+        {
+          component_classes: [
+          'component--roadworks',
+          'component--coordinates-based-list',
+          ],
+          component_title: 'Street and park projects near you'|trans({}, {'context': 'Helsinki near you'}),
+          component_description: 'Browse street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
+          component_content_class: 'roadwork-list',
+        }
+      %}
+        {% block component_content %}
+          {{ roadwork_section }}
 
-        <div class="see-all-button see-all-button--near-results">
-          {% include '@hdbt/navigation/link-button.html.twig' with {
-            type: 'primary',
-            label: 'See all roadworks near you'|t({}, {'context': 'Helsinki near you roadworks search'}),
-            url: roadwork_archive_url,
-          } %}
-        </div>
-      {% endblock component_content %}
-    {% endembed %}
+          <div class="see-all-button see-all-button--near-results">
+            {% include '@hdbt/navigation/link-button.html.twig' with {
+              type: 'primary',
+              label: 'See all roadworks near you'|t({}, {'context': 'Helsinki near you roadworks search'}),
+              url: roadwork_archive_url,
+            } %}
+          </div>
+        {% endblock component_content %}
+      {% endembed %}
+    {% endif %}
 
     {% embed "@hdbt/misc/component.twig" with
       {


### PR DESCRIPTION
# Hiding the "Roadwork near me"-section and search page in "Helsinki near me"
<!-- What problem does this solve? -->

The section still needs a bit more polishing before making it public.

## What was done
<!-- Describe what was done -->

* Hiding the "Roadwork near me"-section and search page in "Helsinki near me"

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_hide_roadworks_near_me`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check that "Roadwork near you" section and route are only accessible when logged in
  * [x] While logged out go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi, then make a search with any address --> You should not see result section "Roadwork near you"
  * [x] While logged out go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tietyot --> You should get an "Access denied" error page
  * [x] While logged in go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi, then make a search with any address --> You should now see result section "Roadwork near you"
  * [x] While logged in go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tietyot --> You should be able to search and get results for an address
* [x] Check that code follows our standards


