### PR TITLE
UHF-11987: Fix LinkedEvents links in HelsinkiNearYou page

### DIFF
--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/DTO/Event.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/DTO/Event.php
@@ -121,13 +121,25 @@ final readonly class Event {
       $item['image'] = Image::createFromArray($image);
     }
 
+    $type = match ($langcode) {
+      'fi' => 'tapahtumat',
+      'sv' => 'kurser',
+      default => 'events',
+    };
+
     $item += [
       'location' => $item['isRemote'] ? 'Internet' : self::getLocationString($langcode, $data['location']),
-      'uri' => Url::fromUri(sprintf('%s/%s/%s', Client::BASE_URL, $langcode, $data['id'])),
+      'uri' => Url::fromUri(sprintf('%s/%s/%s/%s', Client::BASE_URL, $langcode, $type, $data['id'])),
     ];
 
     if ($data['type_id'] === 'Course') {
-      $item['uri'] = Url::fromUri(sprintf('%s/%s/%s', Client::HOBBIES_BASE_URL, $langcode, $data['id']));
+      $type = match ($langcode) {
+        'fi' => 'kurssit',
+        'sv' => 'kurser',
+        default => 'courses',
+      };
+
+      $item['uri'] = Url::fromUri(sprintf('%s/%s/%s/%s', Client::HOBBIES_BASE_URL, $langcode, $type, $data['id']));
     }
 
     if ($item['isRemote']) {

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/DTO/EventTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/DTO/EventTest.php
@@ -56,7 +56,7 @@ class EventTest extends KernelTestBase {
     $this->assertFalse($sut->registrationRequired);
     $this->assertNull($sut->image);
     $this->assertEquals('', $sut->location);
-    $this->assertEquals('https://tapahtumat.hel.fi/sv/123', $sut->uri->toString());
+    $this->assertEquals('https://tapahtumat.hel.fi/sv/kurser/123', $sut->uri->toString());
     $this->assertFalse($sut->isMultiDate);
 
     $data = array_merge($data, [
@@ -77,7 +77,7 @@ class EventTest extends KernelTestBase {
 
     $sut = Event::createFromArray('sv', $data);
 
-    $this->assertEquals('https://harrastukset.hel.fi/sv/123', $sut->uri->toString());
+    $this->assertEquals('https://harrastukset.hel.fi/sv/kurser/123', $sut->uri->toString());
     $this->assertEquals('123', $sut->image->alt);
     $this->assertEquals('name', $sut->image->photographer);
     $this->assertEquals('https://localhost/kuva.jpg', $sut->image->url);


### PR DESCRIPTION
# [UHF-11987](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11987)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix LinkedEvents links in HelsinkiNearYou page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11987`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/tulokset?q=Niittaajankatu+12
* [x] Check https://helfi-etusivu.docker.so/sv/helsingfors-nara-dig/resultat?q=Niittypolku%20-%20Tali%20kolonitr%C3%A4dg%C3%A5rd%20124
* [x] Check https://helfi-etusivu.docker.so/en/helsinki-near-you/results?q=Niittaajankatu+12
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-11987]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ