### PR TITLE
UHF-8574: Fixed no-js mobile menu to have correct frontpage link

### DIFF
--- a/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
+++ b/public/modules/custom/helfi_global_navigation/helfi_global_navigation.module
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\Core\Url;
-use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
# [UHF-8574](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8574)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed no-js mobile menu to have correct language and link to frontpage 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8574`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-8574`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See platform config pr
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1067
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/1041


[UHF-8574]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ