### PR TITLE
UHF-X: Remove access restrictions from the roadworks section

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.routing.yml
@@ -33,7 +33,6 @@ helfi_etusivu.helsinki_near_you_roadworks:
     _big_pipe_force_placeholders: 'TRUE'
   requirements:
     _permission: 'access content'
-    _role: 'authenticated'
 
 helfi_etusivu.helsinki_near_you_feedbacks:
   path: '/helsinki-near-you/feedback'

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/ResultsController.php
@@ -104,7 +104,7 @@ final class ResultsController extends ControllerBase {
       '#roadwork_archive_url' => $this->roadworkDataService->getSeeAllUrl($address, $langcode),
       '#roadwork_section' => $this->buildRoadworks($address, $langcode, 3, new Attribute(['class' => ['card--border']])),
       '#cache' => [
-        'contexts' => ['url.query_args:q', 'user.roles:authenticated'],
+        'contexts' => ['url.query_args:q'],
         'tags' => ['roadwork_section'],
       ],
       '#feedback_archive_url' => Url::fromRoute('helfi_etusivu.helsinki_near_you_feedbacks', options: [

--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi-etusivu/helsinki-near-you-results-page.html.twig
@@ -107,31 +107,29 @@
     {% endif %}
 
     {# Roadwork Section #}
-    {% if logged_in %}
-      {% embed "@hdbt/misc/component.twig" with
-        {
-          component_classes: [
-          'component--roadworks',
-          'component--coordinates-based-list',
-          ],
-          component_title: 'Street and park projects'|trans({}, {'context': 'Helsinki near you'}),
-          component_description: 'Find information on street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
-          component_content_class: 'roadwork-list',
-        }
-      %}
-        {% block component_content %}
-          {{ roadwork_section }}
+    {% embed "@hdbt/misc/component.twig" with
+      {
+        component_classes: [
+        'component--roadworks',
+        'component--coordinates-based-list',
+        ],
+        component_title: 'Street and park projects'|trans({}, {'context': 'Helsinki near you'}),
+        component_description: 'Find information on street and park projects near you.'|trans({}, {'context': 'Helsinki near you'}),
+        component_content_class: 'roadwork-list',
+      }
+    %}
+      {% block component_content %}
+        {{ roadwork_section }}
 
-          <div class="see-all-button see-all-button--near-results">
-            {% include '@hdbt/navigation/link-button.html.twig' with {
-              type: 'primary',
-              label: 'See all street and park projects near you'|t({}, {'context': 'Helsinki near you roadworks search'}),
-              url: roadwork_archive_url,
-            } %}
-          </div>
-        {% endblock component_content %}
-      {% endembed %}
-    {% endif %}
+        <div class="see-all-button see-all-button--near-results">
+          {% include '@hdbt/navigation/link-button.html.twig' with {
+            type: 'primary',
+            label: 'See all street and park projects near you'|t({}, {'context': 'Helsinki near you roadworks search'}),
+            url: roadwork_archive_url,
+          } %}
+        </div>
+      {% endblock component_content %}
+    {% endembed %}
 
     {% embed "@hdbt/misc/component.twig" with
       {


### PR DESCRIPTION
# UHF-X

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Remove access restrictions from the roadworks section. 

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-X_show_roadworks_for_anonymous`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Make sure the roadworks section and block on results page is now visible.
* [ ] Check that the code follows our standards.
