### PR TITLE
UHF-12248: Adjust the ingress text on the feedback page

### DIFF
--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/FeedbackController.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Controller/FeedbackController.php
@@ -25,7 +25,7 @@ final class FeedbackController extends SearchPageControllerBase {
    * {@inheritdoc}
    */
   protected function getDescription(): TranslatableMarkup {
-    return $this->t('You can search for feedback and fault reports  by entering an address.', [], ['context' => 'Helsinki near you']);
+    return $this->t('The search shows results within two kilometers from the address and from the past 90 days.', [], ['context' => 'Helsinki near you']);
   }
 
   /**

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -278,8 +278,8 @@ msgid "Search feedback near you"
 msgstr "Etsi palautteita osoitteellasi"
 
 msgctxt "Helsinki near you"
-msgid "You can search for feedback and fault reports  by entering an address."
-msgstr "Voit etsiä palautteita ja vikailmoituksia osoitteen mukaan."
+msgid "The search shows results within two kilometers from the address and from the past 90 days."
+msgstr "Haku näyttää tuloksia enintään kahden kilometrin etäisyydeltä osoitteesta ja 90 päivän ajalta."
 
 msgctxt "Helsinki near you"
 msgid "Feedback related to your neighbourhood"

--- a/public/modules/custom/helfi_etusivu/translations/sv.po
+++ b/public/modules/custom/helfi_etusivu/translations/sv.po
@@ -271,8 +271,8 @@ msgid "Search feedback near you"
 msgstr "Sök feedback nära dig"
 
 msgctxt "Helsinki near you"
-msgid "You can search for feedback and fault reports  by entering an address."
-msgstr "Du kan söka respons och felanmälningar enligt adress."
+msgid "The search shows results within two kilometers from the address and from the past 90 days."
+msgstr "Sökningen visar resultat inom två kilometer från adressen och från de senaste 90 dagarna."
 
 msgctxt "Helsinki near you"
 msgid "Feedback related to your neighbourhood"


### PR DESCRIPTION
# [UHF-12248](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12248)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Adjust the ingress text on the feedback page.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12248_text_change`
* Run code updates
  * `make drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Go to https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/palautteet and make sure the text under the "Etsi palautteita" is now: "Haku näyttää tuloksia enintään kahden kilometrin etäisyydeltä osoitteesta ja 90 päivän ajalta."
* [ ] Check also the other languages SV: Sökningen visar resultat inom två kilometer från adressen och från de senaste 90 dagarna. EN: The search shows results within two kilometers from the address and from the past 90 days.
* [ ] Check that the code follows our standards.

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->
