### PR TITLE
UHF-12803: Removing all use of all_ongoing*-parameters in Linked Events API calls

### DIFF
--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
@@ -57,8 +57,8 @@ final readonly class Client {
 
     // Use full_text instead of all_ongoing_AND.
     if (isset($options['all_ongoing_AND'])) {
-      $options['full_text'] = $options['full_text'] ?? '';
-      $options['full_text'] .= ' ' . $options['all_ongoing_AND'];
+      $options['full_text'] = !empty($options['full_text']) ? $options['full_text'] . ' ' : '';
+      $options['full_text'] .= $options['all_ongoing_AND'];
       unset($options['all_ongoing_AND']);
     }
 

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
@@ -51,8 +51,15 @@ final readonly class Client {
 
     $options = array_merge($defaultOptions, $options);
 
-    if (!isset($options['all_ongoing_AND'])) {
-      $options['all_ongoing'] = 'true';
+    // Filter ongoing events for Helsinki.
+    $options['ongoing'] = 'true';
+    $options['division'] = 'kunta:helsinki';
+
+    // Use full_text instead of all_ongoing_AND.
+    if (isset($options['all_ongoing_AND'])) {
+      $options['full_text'] = $options['full_text'] ?? '';
+      $options['full_text'] .= ' ' . $options['all_ongoing_AND'];
+      unset($options['all_ongoing_AND']);
     }
 
     // Linked events URLs should end with '/' (URLs without '/' are redirect).

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/LinkedEvents/Client.php
@@ -35,6 +35,9 @@ final readonly class Client {
    *
    * @return string
    *   Resulting api url with params a query string
+   *
+   * @throws \InvalidArgumentException
+   *   If the all_ongoing_AND filter is used.
    */
   public static function getUri(string $langcode, array $options, int $pageSize) : string {
     $defaultOptions = [
@@ -55,11 +58,9 @@ final readonly class Client {
     $options['ongoing'] = 'true';
     $options['division'] = 'kunta:helsinki';
 
-    // Use full_text instead of all_ongoing_AND.
+    // Do not allow the all_ongoing_AND filter.
     if (isset($options['all_ongoing_AND'])) {
-      $options['full_text'] = !empty($options['full_text']) ? $options['full_text'] . ' ' : '';
-      $options['full_text'] .= $options['all_ongoing_AND'];
-      unset($options['all_ongoing_AND']);
+      throw new \InvalidArgumentException('The all_ongoing_AND filter is not allowed. Use full_text instead.');
     }
 
     // Linked events URLs should end with '/' (URLs without '/' are redirect).

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/ClientTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/ClientTest.php
@@ -51,7 +51,7 @@ class ClientTest extends KernelTestBase {
    */
   public function testGetUri() : void {
     $sut = $this->container->get(Client::class);
-    $this->assertEquals('https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=5&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=en&all_ongoing=true', $sut->getUri('en', [], 5));
+    $this->assertEquals('https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=5&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=en&ongoing=true&division=kunta%3Ahelsinki', $sut->getUri('en', [], 5));
   }
 
 }

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/ClientTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/LinkedEvents/ClientTest.php
@@ -54,4 +54,14 @@ class ClientTest extends KernelTestBase {
     $this->assertEquals('https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=5&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=en&ongoing=true&division=kunta%3Ahelsinki', $sut->getUri('en', [], 5));
   }
 
+  /**
+   * Tests that all_ongoing_AND is rejected in getUri().
+   */
+  public function testGetUriRejectsAllOngoingAndFilter() : void {
+    $sut = $this->container->get(Client::class);
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('The all_ongoing_AND filter is not allowed. Use full_text instead.');
+    $sut->getUri('fi', ['all_ongoing_AND' => 'true'], 5);
+  }
+
 }


### PR DESCRIPTION
# [UHF-12803](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12803)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Removed `all_ongoing`-parameter from Linked Events API calls. Replaced with `ongoing` and `division` parameters for similar result set filtering.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12803`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Go to https://helfi-etusivu.docker.so/en/helsinki-near-you/ and search with any address in Helsinki ; event results should appear
* [ ] Follow the "See all events near you"-link, then find the Linked Events API call from inspector Network-tab (calls to https://api.hel.fi/linkedevents/v1/event/); the url should include parameters `ongoing=true&division=kunta%3Ahelsinki`, and should not include `all_ongoing`-parameter.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1239
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/1038


[UHF-12803]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ