### PR TITLE
UHF-12423: Improve breadcrump on helsinki near you page

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.services.yml
@@ -33,6 +33,10 @@ services:
   # Alias for RoadworkDataService to support dependency injection by interface.
   Drupal\helfi_etusivu\HelsinkiNearYou\RoadworkData\RoadworkDataServiceInterface: '@Drupal\helfi_etusivu\HelsinkiNearYou\RoadworkData\RoadworkDataService'
 
+  Drupal\helfi_etusivu\HelsinkiNearYou\Breadcrumb\HelsinkiNearYouBreadcrumbBuilder:
+    tags:
+      - { name: breadcrumb_builder, priority: 1004 }
+
   Drupal\helfi_etusivu\EventSubscriber\ElasticsearchEventSubscriber: ~
 
   Drupal\helfi_etusivu\HelsinkiNearYou\Feedback\Client: ~

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
@@ -76,8 +76,10 @@ final class HelsinkiNearYouBreadcrumbBuilder implements BreadcrumbBuilderInterfa
         // On sub-pages, link back to results with address.
         $breadcrumb->addLink(Link::fromTextAndUrl(
           $text,
-          Url::fromRoute('helfi_etusivu.helsinki_near_you_results', [], [
+          // Javascript apps want to alter this link. Add id for targeting.
+          Url::fromRoute('helfi_etusivu.helsinki_near_you_results', options: [
             'query' => ['home_address' => $address],
+            'attributes' => ['id' => 'hny-address-breadcrumb'],
           ]),
         ));
         $breadcrumb->addLink(Link::createFromRoute($routeEnum->getTitle([]), '<none>'));

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_etusivu\HelsinkiNearYou\Breadcrumb;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\helfi_etusivu\HelsinkiNearYou\Enum\RouteInformationEnum;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Breadcrumb builder for Helsinki Near You pages.
+ */
+final class HelsinkiNearYouBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly RequestStack $requestStack,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function applies(RouteMatchInterface $route_match, ?CacheableMetadata $cacheable_metadata = NULL): bool {
+    $cacheable_metadata?->addCacheContexts(['route']);
+    return RouteInformationEnum::fromRoute($route_match->getRouteName()) !== NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  #[\Override]
+  public function build(RouteMatchInterface $route_match): Breadcrumb {
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addCacheContexts(['route', 'url.query_args:home_address']);
+
+    // Frontpage is injected as first link by
+    // helfi_platform_config_system_breadcrumb_alter.
+    $routeEnum = RouteInformationEnum::fromRoute($route_match->getRouteName());
+
+    if ($routeEnum === RouteInformationEnum::LandingPage) {
+      $breadcrumb->addLink(Link::createFromRoute(
+        RouteInformationEnum::LandingPage->getTitle([]),
+        '<none>',
+      ));
+
+      return $breadcrumb;
+    }
+
+    $breadcrumb->addLink(Link::createFromRoute(
+      RouteInformationEnum::LandingPage->getTitle([]),
+      'helfi_etusivu.helsinki_near_you',
+    ));
+
+    $address = $this->requestStack->getCurrentRequest()?->query->get('home_address');
+
+    if ($address) {
+      $text = new TranslatableMarkup("Results for @address", ['@address' => urldecode($address)], [
+        'context' => 'Helsinki near you',
+      ]);
+
+      if ($routeEnum === RouteInformationEnum::Results) {
+        // On results page, show address as current page.
+        $breadcrumb->addLink(Link::createFromRoute($text, '<none>'));
+      }
+      else {
+        // On sub-pages, link back to results with address.
+        $breadcrumb->addLink(Link::fromTextAndUrl(
+          $text,
+          Url::fromRoute('helfi_etusivu.helsinki_near_you_results', [], [
+            'query' => ['home_address' => $address],
+          ]),
+        ));
+        $breadcrumb->addLink(Link::createFromRoute($routeEnum->getTitle([]), '<none>'));
+      }
+    }
+
+    return $breadcrumb;
+  }
+
+}

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_etusivu\Kernel\HelsinkiNearYou\Breadcrumb;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\ChainBreadcrumbBuilderInterface;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\Project;
+use Drupal\Tests\helfi_api_base\Traits\EnvironmentResolverTrait;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Tests the Helsinki Near You breadcrumb builder.
+ */
+#[Group("helfi_etusivu")]
+#[RunTestsInSeparateProcesses]
+class HelsinkiNearYouBreadcrumbBuilderTest extends KernelTestBase {
+
+  use EnvironmentResolverTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+    'helfi_platform_config',
+    'helfi_etusivu',
+    'config_rewrite',
+    'system',
+    'path_alias',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setActiveProject(Project::ETUSIVU, EnvironmentEnum::Local);
+  }
+
+  /**
+   * Tests breadcrumb on sub-pages (events, roadworks, feedback) with address.
+   */
+  #[DataProvider('pagesProvider')]
+  public function testSubPageWithAddress(string $routeName, string $path, int $expectedLinkCount): void {
+    $breadcrumb = $this->buildBreadcrumb($routeName, $path, 'Kalevankatu 2');
+
+    $links = $breadcrumb->getLinks();
+    $this->assertCount($expectedLinkCount, $links);
+
+    // This link is injected by helfi_platform_config_system_breadcrumb_alter.
+    $this->assertEquals('Front page', (string) $links[0]->getText());
+    $this->assertEquals('<front>', $links[0]->getUrl()->getRouteName());
+
+    $this->assertEquals('Helsinki near you', (string) $links[1]->getText());
+
+    if ($expectedLinkCount > 2) {
+      $this->assertEquals('helfi_etusivu.helsinki_near_you', $links[1]->getUrl()->getRouteName());
+
+      // Address link should point to results page with query parameter.
+      $this->assertStringContainsString('Kalevankatu 2', (string) $links[2]->getText());
+    }
+
+    if ($expectedLinkCount > 3) {
+      $this->assertEquals('helfi_etusivu.helsinki_near_you_results', $links[2]->getUrl()->getRouteName());
+      $this->assertEquals('Kalevankatu 2', $links[2]->getUrl()->getOption('query')['home_address']);
+
+      $this->assertNotEmpty((string) $links[3]->getText());
+    }
+
+    // Last link should always be the current page.
+    $this->assertEquals('<none>', array_last($links)->getUrl()->getRouteName());
+
+    // All previous links should have a real route.
+    foreach (array_slice($links, 0, -1) as $link) {
+      $this->assertNotEquals('<none>', $link->getUrl()->getRouteName());
+    }
+  }
+
+  /**
+   * Data provider for all pages.
+   */
+  public static function pagesProvider(): array {
+    return [
+      'landing page' => [
+        'helfi_etusivu.helsinki_near_you',
+        '/helsinki-near-you',
+        2,
+      ],
+      'results' => [
+        'helfi_etusivu.helsinki_near_you_results',
+        '/helsinki-near-you/results',
+        3,
+      ],
+      'events' => [
+        'helfi_etusivu.helsinki_near_you_events',
+        '/helsinki-near-you/events',
+        4,
+      ],
+      'roadworks' => [
+        'helfi_etusivu.helsinki_near_you_roadworks',
+        '/helsinki-near-you/roadworks',
+        4,
+      ],
+      'feedback' => [
+        'helfi_etusivu.helsinki_near_you_feedback',
+        '/helsinki-near-you/feedback',
+        4,
+      ],
+    ];
+  }
+
+  /**
+   * Builds a breadcrumb for the given route.
+   */
+  private function buildBreadcrumb(string $routeName, string $path, ?string $address = NULL): Breadcrumb {
+    $query = $address ? ['home_address' => $address] : [];
+    $request = Request::create($path, 'GET', $query);
+
+    $route = new Route($path);
+    $routeMatch = new RouteMatch($routeName, $route);
+
+    $requestStack = $this->container->get('request_stack');
+    $requestStack->push($request);
+
+    try {
+      return $this->container->get(ChainBreadcrumbBuilderInterface::class)
+        ->build($routeMatch);
+    }
+    finally {
+      $requestStack->pop();
+    }
+  }
+
+}

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
@@ -57,23 +57,23 @@ class HelsinkiNearYouBreadcrumbBuilderTest extends KernelTestBase {
     $this->assertCount($expectedLinkCount, $links);
 
     // This link is injected by helfi_platform_config_system_breadcrumb_alter.
-    $this->assertEquals('Front page', (string) $links[0]->getText());
+    $this->assertEquals('Front page', $links[0]->getText());
     $this->assertEquals('<front>', $links[0]->getUrl()->getRouteName());
 
-    $this->assertEquals('Helsinki near you', (string) $links[1]->getText());
+    $this->assertEquals('Helsinki near you', $links[1]->getText());
 
     if ($expectedLinkCount > 2) {
       $this->assertEquals('helfi_etusivu.helsinki_near_you', $links[1]->getUrl()->getRouteName());
 
       // Address link should point to results page with query parameter.
-      $this->assertStringContainsString('Kalevankatu 2', (string) $links[2]->getText());
+      $this->assertStringContainsString('Kalevankatu 2', $links[2]->getText());
     }
 
     if ($expectedLinkCount > 3) {
       $this->assertEquals('helfi_etusivu.helsinki_near_you_results', $links[2]->getUrl()->getRouteName());
       $this->assertEquals('Kalevankatu 2', $links[2]->getUrl()->getOption('query')['home_address']);
 
-      $this->assertNotEmpty((string) $links[3]->getText());
+      $this->assertNotEmpty($links[3]->getText());
     }
 
     // Last link should always be the current page.
@@ -87,6 +87,9 @@ class HelsinkiNearYouBreadcrumbBuilderTest extends KernelTestBase {
 
   /**
    * Data provider for all pages.
+   *
+   * @return array<mixed>
+   *   Test data.
    */
   public static function pagesProvider(): array {
     return [

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilderTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\helfi_etusivu\Kernel\HelsinkiNearYou\Breadcrumb;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\ChainBreadcrumbBuilderInterface;
 use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_api_base\Environment\EnvironmentEnum;
 use Drupal\helfi_api_base\Environment\Project;
 use Drupal\Tests\helfi_api_base\Traits\EnvironmentResolverTrait;
@@ -66,7 +67,9 @@ class HelsinkiNearYouBreadcrumbBuilderTest extends KernelTestBase {
       $this->assertEquals('helfi_etusivu.helsinki_near_you', $links[1]->getUrl()->getRouteName());
 
       // Address link should point to results page with query parameter.
-      $this->assertStringContainsString('Kalevankatu 2', $links[2]->getText());
+      $addressLinkText = $links[2]->getText();
+      $this->assertInstanceOf(TranslatableMarkup::class, $addressLinkText);
+      $this->assertStringContainsString('Kalevankatu 2', (string) $addressLinkText);
     }
 
     if ($expectedLinkCount > 3) {

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -306,8 +306,8 @@ msgid "No feedback was found near address @address"
 msgstr "Palautteita ei löytynyt osoitteella @address"
 
 msgctxt "Helsinki near you"
-msgid "Tulokset osoitteella @address"
-msgstr "Results for @address"
+msgid "Results for @address"
+msgstr "Tulokset osoitteella @address"
 
 msgid "Arabic"
 msgstr "Arabia"

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -306,8 +306,8 @@ msgid "No feedback was found near address @address"
 msgstr "Palautteita ei löytynyt osoitteella @address"
 
 msgctxt "Helsinki near you"
-msgstr "Results for @address"
 msgid "Tulokset osoitteella @address"
+msgstr "Results for @address"
 
 msgid "Arabic"
 msgstr "Arabia"

--- a/public/modules/custom/helfi_etusivu/translations/fi.po
+++ b/public/modules/custom/helfi_etusivu/translations/fi.po
@@ -305,6 +305,10 @@ msgctxt "Helsinki near you"
 msgid "No feedback was found near address @address"
 msgstr "Palautteita ei löytynyt osoitteella @address"
 
+msgctxt "Helsinki near you"
+msgstr "Results for @address"
+msgid "Tulokset osoitteella @address"
+
 msgid "Arabic"
 msgstr "Arabia"
 

--- a/public/modules/custom/helfi_etusivu/translations/sv.po
+++ b/public/modules/custom/helfi_etusivu/translations/sv.po
@@ -299,8 +299,8 @@ msgid "No feedback was found near address @address"
 msgstr "Inga responser hittades på adressen @address"
 
 msgctxt "Helsinki near you"
-msgstr "Results for @address"
 msgid "Resultat för @address"
+msgstr "Results for @address"
 
 msgid "Hiding the page"
 msgstr "Schemalagd döljning"

--- a/public/modules/custom/helfi_etusivu/translations/sv.po
+++ b/public/modules/custom/helfi_etusivu/translations/sv.po
@@ -299,8 +299,8 @@ msgid "No feedback was found near address @address"
 msgstr "Inga responser hittades på adressen @address"
 
 msgctxt "Helsinki near you"
-msgid "Resultat för @address"
-msgstr "Results for @address"
+msgid "Results for @address"
+msgstr "Resultat för @address"
 
 msgid "Hiding the page"
 msgstr "Schemalagd döljning"

--- a/public/modules/custom/helfi_etusivu/translations/sv.po
+++ b/public/modules/custom/helfi_etusivu/translations/sv.po
@@ -298,6 +298,10 @@ msgctxt "Helsinki near you"
 msgid "No feedback was found near address @address"
 msgstr "Inga responser hittades på adressen @address"
 
+msgctxt "Helsinki near you"
+msgstr "Results for @address"
+msgid "Resultat för @address"
+
 msgid "Hiding the page"
 msgstr "Schemalagd döljning"
 


### PR DESCRIPTION
# [UHF-12423](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12423)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->

  - Added a custom breadcrumb builder for Helsinki Near You pages that includes the searched address in the breadcrumb trail                                                                                                                                                               
    - On sub-pages, the breadcrumb shows: Front page > Helsinki near you > Results for [address] > [page title], with the address linking back to the results page                                                                                             
    - On the results page, the breadcrumb shows: Front page > Helsinki near you > Results for [address]                                                                                                                                                                                      
  - The address breadcrumb link has an id attribute so JavaScript apps can update it when the user changes address without a page reload                                                                                                                        

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12423`
* Update hdbt
  * `composer require drupal/hdbt:dev-UHF-12423`
* Update
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
  - [x] Navigate to [/fi/helsinki-lahellasi](https://helfi-etusivu.docker.so/fi/helsinki-lahellasi/): breadcrumb shows Etusivu > Helsinki lähelläsi                                                                                                                                                                                                     
  - [x] Search an address. On the results page, breadcrumb shows Etusivu > Helsinki lähelläsi > Tulokset osoitteelle [osoite]                                                                                                                                                                 
  - [x] Click through to events page, breadcrumb shows Etusivu > Helsinki lähelläsi > Tulokset osoitteelle [osoite] > Tapahtumat lähelläsi, and the address links back to results with the correct home_address query parameter                                                               
    - [x] Same for roadworks and feedback sub-pages                                                                                                                                                                                                                                              
  - [x] On sub-pages, change the address in the search form and submit. The breadcrumb text and link should update                                                                                                                                                  
  - [x] Check that the code follows our standards                                                                                                                                                                                                                                              


<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1533


[UHF-12423]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ