### PR TITLE
Fix sentry issue

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,11 +91,6 @@ parameters:
 			path: public/modules/custom/helfi_etusivu/helfi_etusivu.module
 
 		-
-			message: "#^Function helfi_etusivu_page_attachments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_etusivu/helfi_etusivu.module
-
-		-
 			message: "#^Function helfi_etusivu_page_attachments\\(\\) has parameter \\$page with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_etusivu/helfi_etusivu.module

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -519,7 +519,7 @@ function helfi_etusivu_preprocess_node__news_item(array &$variables): void {
 /**
  * Implements hook_page_attachments_HOOK().
  */
-function helfi_etusivu_page_attachments(array &$page) {
+function helfi_etusivu_page_attachments(array &$page): void {
   // Check if the current route matches the desired route.
   $route = \Drupal::routeMatch()->getRouteName();
   $routeInformation = RouteInformationEnum::fromRoute($route);

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.module
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.module
@@ -522,6 +522,10 @@ function helfi_etusivu_preprocess_node__news_item(array &$variables): void {
 function helfi_etusivu_page_attachments(array &$page): void {
   // Check if the current route matches the desired route.
   $route = \Drupal::routeMatch()->getRouteName();
+  if (!$route) {
+    return;
+  }
+
   $routeInformation = RouteInformationEnum::fromRoute($route);
 
   if ($routeInformation) {

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Breadcrumb/HelsinkiNearYouBreadcrumbBuilder.php
@@ -32,7 +32,8 @@ final class HelsinkiNearYouBreadcrumbBuilder implements BreadcrumbBuilderInterfa
   #[\Override]
   public function applies(RouteMatchInterface $route_match, ?CacheableMetadata $cacheable_metadata = NULL): bool {
     $cacheable_metadata?->addCacheContexts(['route']);
-    return RouteInformationEnum::fromRoute($route_match->getRouteName()) !== NULL;
+    $route = $route_match->getRouteName();
+    return $route && RouteInformationEnum::fromRoute($route) !== NULL;
   }
 
   /**
@@ -45,7 +46,9 @@ final class HelsinkiNearYouBreadcrumbBuilder implements BreadcrumbBuilderInterfa
 
     // Frontpage is injected as first link by
     // helfi_platform_config_system_breadcrumb_alter.
-    $routeEnum = RouteInformationEnum::fromRoute($route_match->getRouteName());
+    $route = $route_match->getRouteName();
+    assert($route);
+    $routeEnum = RouteInformationEnum::fromRoute($route);
 
     if ($routeEnum === RouteInformationEnum::LandingPage) {
       $breadcrumb->addLink(Link::createFromRoute(

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Enum/RouteInformationEnum.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Enum/RouteInformationEnum.php
@@ -78,14 +78,14 @@ enum RouteInformationEnum {
    * If the provided route does not have a matching enum
    * case, `null` is returned.
    *
-   * @param string|null $route
+   * @param string $route
    *   The route name.
    *
    * @return static|null
    *   The corresponding enum case if a match exists, or
    *   NULL if no match was found.
    */
-  public static function fromRoute(string|NULL $route): ?self {
+  public static function fromRoute(string $route): ?self {
     return match($route) {
       'helfi_etusivu.helsinki_near_you' => self::LandingPage,
       'helfi_etusivu.helsinki_near_you_results' => self::Results,

--- a/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Enum/RouteInformationEnum.php
+++ b/public/modules/custom/helfi_etusivu/src/HelsinkiNearYou/Enum/RouteInformationEnum.php
@@ -78,14 +78,14 @@ enum RouteInformationEnum {
    * If the provided route does not have a matching enum
    * case, `null` is returned.
    *
-   * @param string $route
+   * @param string|null $route
    *   The route name.
    *
    * @return static|null
    *   The corresponding enum case if a match exists, or
    *   NULL if no match was found.
    */
-  public static function fromRoute(string $route): ?self {
+  public static function fromRoute(string|NULL $route): ?self {
     return match($route) {
       'helfi_etusivu.helsinki_near_you' => self::LandingPage,
       'helfi_etusivu.helsinki_near_you_results' => self::Results,

--- a/public/modules/custom/helfi_etusivu/src/Plugin/Block/HelsinkiNearYouHeroBlock.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/Block/HelsinkiNearYouHeroBlock.php
@@ -75,6 +75,9 @@ final class HelsinkiNearYouHeroBlock extends BlockBase implements ContainerFacto
    */
   public function build() : array {
     $route = $this->routeMatch->getRouteName();
+    if (!$route) {
+      return [];
+    }
     $routeInformation = RouteInformationEnum::fromRoute($route);
     if (!$routeInformation) {
       return [];


### PR DESCRIPTION
Fixes https://sentry.hel.fi/organizations/city-of-helsinki/issues/73639.

[RouteMatchInterface::getRouteName()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Routing%21RouteMatchInterface.php/function/RouteMatchInterface%3A%3AgetRouteName/11.x) can return NULL in some cases.