### PR TITLE
UHF-13114

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2647,16 +2647,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "11.3.12",
+            "version": "11.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "743f30ab2cb2ea2166499b1b568988ddc9f4ee02"
+                "reference": "a9334c83b262556bcd17785df981e0f49d1f191d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/743f30ab2cb2ea2166499b1b568988ddc9f4ee02",
-                "reference": "743f30ab2cb2ea2166499b1b568988ddc9f4ee02",
+                "url": "https://api.github.com/repos/drupal/core/zipball/a9334c83b262556bcd17785df981e0f49d1f191d",
+                "reference": "a9334c83b262556bcd17785df981e0f49d1f191d",
                 "shasum": ""
             },
             "require": {
@@ -2681,7 +2681,7 @@
                 "ext-xml": "*",
                 "ext-zlib": "*",
                 "guzzlehttp/guzzle": "^7.10",
-                "guzzlehttp/psr7": "^2.10.2",
+                "guzzlehttp/psr7": "^2.8.0",
                 "masterminds/html5": "^2.7",
                 "mck89/peast": "^1.17.4",
                 "pear/archive_tar": "^1.4.14",
@@ -2814,13 +2814,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/11.3.12"
+                "source": "https://github.com/drupal/core/tree/11.3.13"
             },
-            "time": "2026-06-17T15:59:46+00:00"
+            "time": "2026-06-23T07:19:39+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "11.3.12",
+            "version": "11.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2864,7 +2864,7 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.12"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.3.13"
             },
             "time": "2026-02-10T11:39:53+00:00"
         },
@@ -9768,22 +9768,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -9796,7 +9796,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -9876,7 +9876,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -9892,7 +9892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T22:11:48+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -9980,16 +9980,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -10079,7 +10079,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -10095,7 +10095,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T21:50:11+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/composer.lock
+++ b/composer.lock
@@ -18341,7 +18341,7 @@
         },
         {
             "name": "drupal/core-dev",
-            "version": "11.3.12",
+            "version": "11.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",

--- a/conf/cmi/search_api.index.news.yml
+++ b/conf/cmi/search_api.index.news.yml
@@ -70,6 +70,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead_in
+  field_lead_in_raw:
+    label: 'Ingress (raw)'
+    datasource_id: 'entity:node'
+    property_path: field_lead_in
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_lead_in
   field_main_image_caption:
     label: Caption
     datasource_id: 'entity:node'

--- a/public/modules/custom/helfi_etusivu/src/Plugin/rest/resource/NewsRssResource.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/rest/resource/NewsRssResource.php
@@ -193,10 +193,11 @@ final class NewsRssResource extends ResourceBase {
         );
       }
     }
+    $leadText = $this->parseSourceValue('field_lead_in_raw', $result) ?? '';
     return new RssItem(
       title: (string) $this->parseSourceValue('title', $result),
       link: (string) $this->parseSourceValue('url', $result),
-      description: (string) $this->parseSourceValue('field_lead_in_raw', $result) ?? '',
+      description: (string) $leadText,
       pubDate: DrupalDateTime::createFromTimestamp((int) $this->parseSourceValue('published_at', $result))->format('r'),
       guid: (string) $this->parseSourceValue('uuid', $result),
       enclosure: $enclosure,

--- a/public/modules/custom/helfi_etusivu/src/Plugin/rest/resource/NewsRssResource.php
+++ b/public/modules/custom/helfi_etusivu/src/Plugin/rest/resource/NewsRssResource.php
@@ -196,7 +196,7 @@ final class NewsRssResource extends ResourceBase {
     return new RssItem(
       title: (string) $this->parseSourceValue('title', $result),
       link: (string) $this->parseSourceValue('url', $result),
-      description: (string) $this->parseSourceValue('field_lead_in', $result),
+      description: (string) $this->parseSourceValue('field_lead_in_raw', $result) ?? '',
       pubDate: DrupalDateTime::createFromTimestamp((int) $this->parseSourceValue('published_at', $result))->format('r'),
       guid: (string) $this->parseSourceValue('uuid', $result),
       enclosure: $enclosure,

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/NewsRss/NewsRssResourceTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/NewsRss/NewsRssResourceTest.php
@@ -169,7 +169,7 @@ class NewsRssResourceTest extends EtusivuElasticTestBase {
       body: [
         'title' => [$title],
         'url' => [$url],
-        'field_lead_in' => [$description],
+        'field_lead_in_raw' => [$description],
         'published_at' => [$publishedAt],
         'uuid' => [$uuid],
         'search_api_language' => [$language],

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/NewsRss/NewsRssResourceTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/NewsRss/NewsRssResourceTest.php
@@ -169,6 +169,7 @@ class NewsRssResourceTest extends EtusivuElasticTestBase {
       body: [
         'title' => [$title],
         'url' => [$url],
+        'field_lead_in' => [$description],
         'field_lead_in_raw' => [$description],
         'published_at' => [$publishedAt],
         'uuid' => [$uuid],


### PR DESCRIPTION
# [UHF-13114](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13114)

News indexes description field is processed with lowercase processor for better search results. RSS needs a description-text with uppercase letter.

## What was done
- Added new raw (unprocessed) lead-in field to news index for the RSS feed
- RSS now shows the unprocessed lead-in as description

## How to install
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13114`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Go to /uutiset/rss
- The RSS should load but description might be empty (depending if you have stuff in your index)
  - Should not cause error/white screen 
- Run indexing: `drush sapi-rt news` and `drush sapi-i news` and clear cache just in case
- Go to /uutiset/rss
- The description fields' content should be unprocessed (has uppercase letters) 


[UHF-13114]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ