### PR TITLE
UHF-13357: Fix search promotion sorting

### DIFF
--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -873,3 +873,18 @@ function helfi_etusivu_update_11010(): void {
     ->isNull('enable_link_check')
     ->execute();
 }
+
+/**
+ * Trim whitespace from search promotion titles and keywords.
+ */
+function helfi_etusivu_update_11011(): void {
+  $storage = \Drupal::entityTypeManager()
+    ->getStorage('helfi_search_promotion');
+
+ // Search promotions contain leading whitespace in titles
+ // Re-saving the entities lets Promotion::preSave() normalize
+ // the values.
+  foreach ($storage->loadMultiple() as $promotion) {
+    $promotion->save();
+  }
+}

--- a/public/modules/custom/helfi_etusivu/helfi_etusivu.install
+++ b/public/modules/custom/helfi_etusivu/helfi_etusivu.install
@@ -881,9 +881,9 @@ function helfi_etusivu_update_11011(): void {
   $storage = \Drupal::entityTypeManager()
     ->getStorage('helfi_search_promotion');
 
- // Search promotions contain leading whitespace in titles
- // Re-saving the entities lets Promotion::preSave() normalize
- // the values.
+  // Search promotions contain leading whitespace in titles
+  // Re-saving the entities lets Promotion::preSave() normalize
+  // the values.
   foreach ($storage->loadMultiple() as $promotion) {
     $promotion->save();
   }

--- a/public/modules/custom/helfi_etusivu/src/Entity/Search/Promotion.php
+++ b/public/modules/custom/helfi_etusivu/src/Entity/Search/Promotion.php
@@ -203,18 +203,20 @@ final class Promotion extends ContentEntityBase implements EntityPublishedInterf
   public function preSave(EntityStorageInterface $storage): void {
     parent::preSave($storage);
 
-    // Normalize titles and keywords on save.
+    // Normalize titles and keywords on save. Titles can contain
+    // unicode whitespace, most likely originating from Word document
+    // copy-paste.
     foreach ($this->getTranslationLanguages() as $langcode => $language) {
       $translation = $this->getTranslation($langcode);
 
       $title = $translation->get('title')->value;
-      if (is_string($title) && ($trimmed = self::trimWhitespace($title)) !== $title) {
+      if (is_string($title) && ($trimmed = mb_trim($title)) !== $title) {
         $translation->set('title', $trimmed);
       }
 
       $keywords = $translation->getKeywords();
       $trimmedKeywords = array_values(array_filter(
-        array_map(self::trimWhitespace(...), $keywords),
+        array_map(mb_trim(...), $keywords),
         static fn (string $keyword): bool => $keyword !== '',
       ));
       if ($trimmedKeywords !== $keywords) {
@@ -239,18 +241,6 @@ final class Promotion extends ContentEntityBase implements EntityPublishedInterf
     // cron run re-verifies the new URL instead of reusing prior results.
     $this->setLastChecked(0);
     $this->resetFailedCheckCount();
-  }
-
-  /**
-   * Trims ASCII and Unicode whitespace from both ends of a string.
-   *
-   * The regex is crafted to handle Unicode whitespace characters
-   * that we have detected in keyword titles, such as NO-BREAK SPACE
-   * (U+00A0) and NARROW NO-BREAK SPACE (U+202F). These most likely
-   * originate from Word document copy-paste.
-   */
-  private static function trimWhitespace(string $value): string {
-    return preg_replace('/^[\s\p{Z}\p{C}]+|[\s\p{Z}\p{C}]+$/u', '', $value) ?? trim($value);
   }
 
   /**

--- a/public/modules/custom/helfi_etusivu/src/Entity/Search/Promotion.php
+++ b/public/modules/custom/helfi_etusivu/src/Entity/Search/Promotion.php
@@ -203,6 +203,25 @@ final class Promotion extends ContentEntityBase implements EntityPublishedInterf
   public function preSave(EntityStorageInterface $storage): void {
     parent::preSave($storage);
 
+    // Normalize titles and keywords on save.
+    foreach ($this->getTranslationLanguages() as $langcode => $language) {
+      $translation = $this->getTranslation($langcode);
+
+      $title = $translation->get('title')->value;
+      if (is_string($title) && ($trimmed = self::trimWhitespace($title)) !== $title) {
+        $translation->set('title', $trimmed);
+      }
+
+      $keywords = $translation->getKeywords();
+      $trimmedKeywords = array_values(array_filter(
+        array_map(self::trimWhitespace(...), $keywords),
+        static fn (string $keyword): bool => $keyword !== '',
+      ));
+      if ($trimmedKeywords !== $keywords) {
+        $translation->set('keywords', $trimmedKeywords);
+      }
+    }
+
     $original = $this->original ?? NULL;
     if (!$original instanceof self) {
       return;
@@ -220,6 +239,18 @@ final class Promotion extends ContentEntityBase implements EntityPublishedInterf
     // cron run re-verifies the new URL instead of reusing prior results.
     $this->setLastChecked(0);
     $this->resetFailedCheckCount();
+  }
+
+  /**
+   * Trims ASCII and Unicode whitespace from both ends of a string.
+   *
+   * The regex is crafted to handle Unicode whitespace characters
+   * that we have detected in keyword titles, such as NO-BREAK SPACE
+   * (U+00A0) and NARROW NO-BREAK SPACE (U+202F). These most likely
+   * originate from Word document copy-paste.
+   */
+  private static function trimWhitespace(string $value): string {
+    return preg_replace('/^[\s\p{Z}\p{C}]+|[\s\p{Z}\p{C}]+$/u', '', $value) ?? trim($value);
   }
 
   /**

--- a/public/modules/custom/helfi_etusivu/tests/src/Kernel/Entity/Search/PromotionTest.php
+++ b/public/modules/custom/helfi_etusivu/tests/src/Kernel/Entity/Search/PromotionTest.php
@@ -105,6 +105,26 @@ class PromotionTest extends EntityKernelTestBase {
   }
 
   /**
+   * Tests that titles and keywords are trimmed on save.
+   */
+  public function testWhitespaceIsTrimmedOnSave(): void {
+    $promotion = Promotion::create([
+      'bundle' => 'promotion',
+      'title' => '  Advisory services ',
+      'description' => 'Test description',
+      'link' => 'https://example.com',
+      // Includes Unicode whitespace: NARROW NO-BREAK SPACE (U+202F)
+      // and NO-BREAK SPACE (U+00A0).
+      'keywords' => [' Advisory services', "Advisory\u{202F}", "\u{00A0}", '  '],
+    ]);
+    $promotion->save();
+
+    $reloaded = Promotion::load($promotion->id());
+    $this->assertSame('Advisory services', $reloaded->label());
+    $this->assertSame(['Advisory services', 'Advisory'], $reloaded->getKeywords());
+  }
+
+  /**
    * Tests scheduled publishing and unpublishing of a promotion.
    */
   public function testSchedulerPublishAndUnpublish(): void {


### PR DESCRIPTION
# [UHF-13357](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13357)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
Alphabetical sorting is messed up in search promotion view. This is caused by extra whitespace in promotion titles, most likely originating from copy-pasting from Word document.

<img width="1764" height="511" alt="image" src="https://github.com/user-attachments/assets/1631d8de-5da6-4f75-8a10-62f355902ff3" />

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13357`
* Run code updates
  * `composer install`
  * `make drush-deploy`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [x] https://helfi-etusivu.docker.so/fi/admin/search?order=title&sort=asc should sort correctly
* [x] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 


[UHF-13357]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ